### PR TITLE
Base 컴포넌트 정의

### DIFF
--- a/Bridge.xcodeproj/project.pbxproj
+++ b/Bridge.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		7BA36CC92A9E1640000DAB02 /* Reusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA36CC82A9E1640000DAB02 /* Reusable.swift */; };
 		7BA36CCE2A9E185A000DAB02 /* ChatRoomTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA36CCD2A9E185A000DAB02 /* ChatRoomTableViewCell.swift */; };
 		7BA36CD02A9E1888000DAB02 /* BaseTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA36CCF2A9E1888000DAB02 /* BaseTableViewCell.swift */; };
+		7BA36CD32A9F3F6B000DAB02 /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA36CD22A9F3F6B000DAB02 /* BaseView.swift */; };
 		7BB2C23F2A98512400AA2328 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB2C23E2A98512400AA2328 /* AppCoordinator.swift */; };
 		7BB2C2412A9851B600AA2328 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB2C2402A9851B600AA2328 /* Coordinator.swift */; };
 		7BB2C2472A98549D00AA2328 /* TabBarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB2C2462A98549D00AA2328 /* TabBarCoordinator.swift */; };
@@ -75,6 +76,7 @@
 		7BA36CC82A9E1640000DAB02 /* Reusable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reusable.swift; sourceTree = "<group>"; };
 		7BA36CCD2A9E185A000DAB02 /* ChatRoomTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomTableViewCell.swift; sourceTree = "<group>"; };
 		7BA36CCF2A9E1888000DAB02 /* BaseTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableViewCell.swift; sourceTree = "<group>"; };
+		7BA36CD22A9F3F6B000DAB02 /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
 		7BB2C23E2A98512400AA2328 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		7BB2C2402A9851B600AA2328 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		7BB2C2462A98549D00AA2328 /* TabBarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarCoordinator.swift; sourceTree = "<group>"; };
@@ -304,6 +306,7 @@
 		7BA36CC22A9E10FA000DAB02 /* Base */ = {
 			isa = PBXGroup;
 			children = (
+				7BA36CD22A9F3F6B000DAB02 /* BaseView.swift */,
 				7BA36CC32A9E1134000DAB02 /* BaseViewController.swift */,
 				7BA36CCF2A9E1888000DAB02 /* BaseTableViewCell.swift */,
 			);
@@ -545,6 +548,7 @@
 				7BA36CC42A9E1134000DAB02 /* BaseViewController.swift in Sources */,
 				7BA36C8E2A9C4B33000DAB02 /* ViewModelType.swift in Sources */,
 				7CF93E052A9C65490013EBD6 /* MainCoordinator.swift in Sources */,
+				7BA36CD32A9F3F6B000DAB02 /* BaseView.swift in Sources */,
 				7CF93E072A9C65870013EBD6 /* MainViewController.swift in Sources */,
 				7BA36CBC2A9DA2D1000DAB02 /* NetworkService.swift in Sources */,
 			);

--- a/Bridge/Sources/Presenter/Common/Base/BaseTableViewCell.swift
+++ b/Bridge/Sources/Presenter/Common/Base/BaseTableViewCell.swift
@@ -16,10 +16,23 @@ class BaseTableViewCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
         backgroundColor = .white
+        
+        configureAttributes()
+        configureUI()
+        bind()
     }
     
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    /// 기타 속성들을 설정하기 위한 메서드
+    func configureAttributes() { }
+    
+    /// UI와 관련된 속성들(뷰 계층, 레이아웃 등)을 설정하기 위한 메서드
+    func configureUI() { }
+    
+    /// 뷰 모델과 뷰를 바인딩하기 위한 메서드
+    func bind() { }
 }

--- a/Bridge/Sources/Presenter/Common/Base/BaseView.swift
+++ b/Bridge/Sources/Presenter/Common/Base/BaseView.swift
@@ -1,0 +1,38 @@
+//
+//  BaseView.swift
+//  Bridge
+//
+//  Created by 정호윤 on 2023/08/30.
+//
+
+import UIKit
+import RxSwift
+
+class BaseView: UIView {
+    
+    var disposeBag = DisposeBag()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        backgroundColor = .white
+        
+        configureAttributes()
+        configureUI()
+        bind()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    /// 기타 속성들을 설정하기 위한 메서드
+    func configureAttributes() { }
+    
+    /// UI와 관련된 속성들(뷰 계층, 레이아웃 등)을 설정하기 위한 메서드
+    func configureUI() { }
+    
+    /// 뷰 모델과 뷰를 바인딩하기 위한 메서드
+    func bind() { }
+}

--- a/Bridge/Sources/Presenter/Common/Base/BaseView.swift
+++ b/Bridge/Sources/Presenter/Common/Base/BaseView.swift
@@ -18,7 +18,7 @@ class BaseView: UIView {
         backgroundColor = .white
         
         configureAttributes()
-        configureUI()
+        configureLayouts()
         bind()
     }
     
@@ -31,7 +31,7 @@ class BaseView: UIView {
     func configureAttributes() { }
     
     /// UI와 관련된 속성들(뷰 계층, 레이아웃 등)을 설정하기 위한 메서드
-    func configureUI() { }
+    func configureLayouts() { }
     
     /// 뷰 모델과 뷰를 바인딩하기 위한 메서드
     func bind() { }

--- a/Bridge/Sources/Presenter/Common/Base/BaseViewController.swift
+++ b/Bridge/Sources/Presenter/Common/Base/BaseViewController.swift
@@ -25,7 +25,7 @@ class BaseViewController: UIViewController {
     func configureAttributes() { }
     
     /// UI와 관련된 속성들(뷰 계층, 레이아웃 등)을 설정하기 위한 메서드
-    func configureUI() { }
+    func configureLayouts() { }
     
     /// 뷰 모델과 뷰를 바인딩하기 위한 메서드
     func bind() { }
@@ -38,7 +38,7 @@ extension BaseViewController {
         view.backgroundColor = .white
         
         configureAttributes()
-        configureUI()
+        configureLayouts()
         bind()
     }
 }

--- a/Bridge/Sources/Presenter/Common/Base/BaseViewController.swift
+++ b/Bridge/Sources/Presenter/Common/Base/BaseViewController.swift
@@ -21,9 +21,24 @@ class BaseViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    /// 기타 속성(데이터 소스, 네비게이션 바 등)들을 설정하기 위한 메서드
+    func configureAttributes() { }
+    
+    /// UI와 관련된 속성들(뷰 계층, 레이아웃 등)을 설정하기 위한 메서드
+    func configureUI() { }
+    
+    /// 뷰 모델과 뷰를 바인딩하기 위한 메서드
+    func bind() { }
+}
+
+// MARK: - Life cycles
+extension BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         view.backgroundColor = .white
+        
+        configureAttributes()
+        configureUI()
+        bind()
     }
 }


### PR DESCRIPTION
## 배경
- `disposeBag`과 같은 코드들의 불필요한 반복을 하지 않고 싶었습니다.
- 뷰 컨트롤러가 비대해지는 것을 막고싶었습니다.

## 효과
- 코드의 불필요한 반복이 사라집니다.
- 일관된 함수에서 일관된 작업을 수행함으로써 협업 시 코드의 일관성 및 가독성이 향상됩니다.

## 작업 내용
close #15 

## 리뷰 노트
- 해당 변경사항 뿐 아니라, 제 실수로 인해 임의 머지한 `Reusable`과 `UITableView+`파일도 확인해주시면 좋을것 같습니다.
- 모두 비슷한 맥락입니다.
