### PR TITLE
채팅방 셀 디자인 수정

### DIFF
--- a/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomCell.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomCell.swift
@@ -16,15 +16,15 @@ final class ChatRoomCell: BaseTableViewCell {
         let view = UIView()
         view.backgroundColor = .systemGray5
         view.layer.cornerRadius = 16
-        view.clipsToBounds = true
         return view
     }()
     
     private let profileImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFill
         imageView.backgroundColor = .systemGray4
+        imageView.layer.cornerRadius = 22
         imageView.clipsToBounds = true
+        imageView.contentMode = .scaleAspectFill
         return imageView
     }()
     
@@ -54,6 +54,7 @@ final class ChatRoomCell: BaseTableViewCell {
         label.textColor = .white
         label.font = .systemFont(ofSize: 12)
         label.textAlignment = .center
+        label.layer.cornerRadius = 9
         label.clipsToBounds = true
         return label
     }()
@@ -67,34 +68,37 @@ final class ChatRoomCell: BaseTableViewCell {
         messagePreviewLabel.text = ""
     }
     
-    // MARK: - Configurations
+    // MARK: - Layouts
     override func configureLayouts() {
         contentView.addSubview(chatRoomBackgroundView)
         
-        let padding: CGFloat = 24
-        let margin: CGFloat = 8
+        let componentOffset: CGFloat = 8
+        let containeroffset: CGFloat = 24
         
-        chatRoomBackgroundView.flex.direction(.row).padding(padding).alignItems(.center).define { flex in
-            flex.addItem(profileImageView).size(44).cornerRadius(22).aspectRatio(1)
+        chatRoomBackgroundView.flex.direction(.row).alignItems(.center).define { flex in
+            flex.addItem(profileImageView).size(44).marginLeft(containeroffset)
             
-            flex.addItem().direction(.column).width(200).marginHorizontal(margin * 2).define { flex in
-                flex.addItem().direction(.row).marginBottom(margin).define { flex in
-                    flex.addItem(nameLabel)
-                    flex.addItem(timeLabel).marginLeft(margin)
+            flex.addItem().direction(.column).marginHorizontal(16).define { flex in
+                flex.addItem().direction(.row).marginBottom(componentOffset).define { flex in
+                    flex.addItem(nameLabel).grow(1)
+                    flex.addItem().size(componentOffset)
+                    flex.addItem(timeLabel).shrink(1)
                 }
                 
                 flex.addItem(messagePreviewLabel)
             }
             
-            flex.addItem(unreadMessagesCountLabel).size(18).cornerRadius(9)
+            flex.addItem(unreadMessagesCountLabel).size(18).position(.absolute).right(containeroffset)
         }
     }
+
     
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        let offset: CGFloat = 16
-        chatRoomBackgroundView.pin.top(offset).left(offset).right(offset).bottom()
+        let horizontalMargin: CGFloat = 16
+        let verticalMargin: CGFloat = 8
+        chatRoomBackgroundView.pin.horizontally(horizontalMargin).vertically(verticalMargin)
         chatRoomBackgroundView.flex.layout()
     }
 }

--- a/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewController.swift
@@ -17,7 +17,7 @@ final class ChatRoomListViewController: BaseViewController {
         tableView.register(ChatRoomCell.self)
         tableView.backgroundColor = .white
         tableView.rowHeight = 104
-        tableView.contentInset = UIEdgeInsets(top: 8, left: 0, bottom: 0, right: 0)
+        tableView.contentInset = UIEdgeInsets(top: 16, left: 0, bottom: 0, right: 0)
         tableView.separatorStyle = .none
         return tableView
     }()

--- a/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewController.swift
@@ -91,7 +91,7 @@ extension ChatRoomListViewController {
     }
     
     private func configureDataSource() -> DataSource {
-        UITableViewDiffableDataSource(tableView: chatRoomListTableView) { tableView, indexPath, item in
+        DataSource(tableView: chatRoomListTableView) { tableView, indexPath, item in
             guard let cell = tableView.dequeueReusableCell(ChatRoomCell.self, for: indexPath) else {
                 return UITableViewCell()
             }


### PR DESCRIPTION
## 배경
- 밀어서 나가기 기능 구현 중 나가기 버튼의 사이즈가 셀의 사이즈와 동일해 어색해 보였습니다.

## 작업 내용
close #25 
- 셀의 오프셋을 조정했습니다.

## 스크린샷
|Before|After|
|---|---|
|<img src = "https://github.com/bridge0813/bridge-ios/assets/65343417/46d9efbd-6378-4958-abf4-e6d9a66d5a7e" height = 200>|<img src = "https://github.com/bridge0813/bridge-ios/assets/65343417/b38e0c4c-dcbb-47f5-b306-b3a6c82002a6" height = 600>|

## 리뷰 노트
- 일단 PR 올렸습니다만, 셀의 flexlayout 관련해서는 조금 더 수정해볼것 같습니다.
