### PR TITLE
채팅방 엔티티 및 셀 수정

### DIFF
--- a/Bridge/Sources/Data/Network/DTOs/Chat/ChatRoomDTO.swift
+++ b/Bridge/Sources/Data/Network/DTOs/Chat/ChatRoomDTO.swift
@@ -67,7 +67,7 @@ extension ChatRoomDTO {
             name: "채팅방 2",
             latestMessageReceivedTime: "2023-09-04T15:45:10+00:00",
             latestMessageType: "text",
-            latestMessageContent: "수신된 가장 최근 메시지 중 긴 메시지가 어떻게 보여질지에 대한 테스트입니다.",
+            latestMessageContent: "수신된 가장 최근 메시지를 표시합니다.",
             unreadMessageCount: 0
         ),
         ChatRoomDTO(

--- a/Bridge/Sources/Data/Network/DTOs/Chat/ChatRoomDTO.swift
+++ b/Bridge/Sources/Data/Network/DTOs/Chat/ChatRoomDTO.swift
@@ -43,7 +43,7 @@ extension String {
         // Date 객체를 "오전/오후 x시 x분" 형태로 변환
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")
-        formatter.setLocalizedDateFormatFromTemplate("ahmm")
+        formatter.dateFormat = "a h시 mm분"
         
         return formatter.string(from: date)
     }

--- a/Bridge/Sources/Data/Network/DTOs/Chat/ChatRoomDTO.swift
+++ b/Bridge/Sources/Data/Network/DTOs/Chat/ChatRoomDTO.swift
@@ -14,7 +14,7 @@ struct ChatRoomDTO: Codable {
     let latestMessageReceivedTime: String
     let latestMessageType: String
     let latestMessageContent: String
-    let unreadMessageCount: Int
+    let unreadMessageCount: String
 }
 
 // MARK: - For test
@@ -29,7 +29,7 @@ extension ChatRoomDTO {
                 type: .text,
                 content: latestMessageContent
             ),
-            unreadMessageCount: 0
+            unreadMessageCount: unreadMessageCount
         )
     }
 }
@@ -59,7 +59,7 @@ extension ChatRoomDTO {
             latestMessageReceivedTime: "2023-09-04T09:15:30+00:00",
             latestMessageType: "text",
             latestMessageContent: "수신된 가장 최근 메시지를 표시합니다.",
-            unreadMessageCount: 0
+            unreadMessageCount: "0"
         ),
         ChatRoomDTO(
             id: "2",
@@ -68,7 +68,7 @@ extension ChatRoomDTO {
             latestMessageReceivedTime: "2023-09-04T15:45:10+00:00",
             latestMessageType: "text",
             latestMessageContent: "수신된 가장 최근 메시지를 표시합니다.",
-            unreadMessageCount: 0
+            unreadMessageCount: "100"
         ),
         ChatRoomDTO(
             id: "3",
@@ -77,7 +77,7 @@ extension ChatRoomDTO {
             latestMessageReceivedTime: "2023-09-04T11:00:00+00:00",
             latestMessageType: "image",
             latestMessageContent: "이미지가 수신된 경우의 미리보기 메시지입니다.",
-            unreadMessageCount: 0
+            unreadMessageCount: "3"
         ),
         ChatRoomDTO(
             id: "4",
@@ -86,7 +86,7 @@ extension ChatRoomDTO {
             latestMessageReceivedTime: "2023-09-04T19:30:20+00:00",
             latestMessageType: "text",
             latestMessageContent: "수신된 가장 최근 메시지를 표시합니다.",
-            unreadMessageCount: 0
+            unreadMessageCount: "999"
         ),
         ChatRoomDTO(
             id: "5",
@@ -95,7 +95,7 @@ extension ChatRoomDTO {
             latestMessageReceivedTime: "2023-09-04T04:55:55+00:00",
             latestMessageType: "text",
             latestMessageContent: "수신된 가장 최근 메시지를 표시합니다.",
-            unreadMessageCount: 0
+            unreadMessageCount: "1"
         ),
         ChatRoomDTO(
             id: "6",
@@ -104,7 +104,7 @@ extension ChatRoomDTO {
             latestMessageReceivedTime: "2023-09-04T12:34:56+00:00",
             latestMessageType: "text",
             latestMessageContent: "수신된 가장 최근 메시지를 표시합니다.",
-            unreadMessageCount: 0
+            unreadMessageCount: "7"
         )
     ]
 }

--- a/Bridge/Sources/Data/Network/DTOs/Chat/ChatRoomDTO.swift
+++ b/Bridge/Sources/Data/Network/DTOs/Chat/ChatRoomDTO.swift
@@ -9,22 +9,102 @@ import Foundation
 
 struct ChatRoomDTO: Codable {
     let id: String
-    let profileImage: URL?
+    let profileImage: String
     let name: String
-    let time: Date
-    let messageType: Chat.MessageType
-    let messagePreview: String
+    let latestMessageReceivedTime: String
+    let latestMessageType: String
+    let latestMessageContent: String
+    let unreadMessageCount: Int
 }
 
+// MARK: - For test
 extension ChatRoomDTO {
-    func toModel() -> ChatRoom {
+    func toDomain() -> ChatRoom {
         ChatRoom(
             id: id,
-            profileImage: profileImage,
+            profileImageURL: URL(string: profileImage),
             name: name,
-            time: time,
-            messageType: messageType,
-            messagePreview: messagePreview
+            latestMessage: ChatRoom.LatestMessage(
+                receivedTime: latestMessageReceivedTime.toTimeString() ?? "오류",
+                type: .text,
+                content: latestMessageContent
+            ),
+            unreadMessageCount: 0
         )
     }
+}
+
+extension String {
+    func toTimeString() -> String? {
+        // ISO 8601 문자열을 Date 객체로 변환
+        let isoFormatter = ISO8601DateFormatter()
+        guard let date = isoFormatter.date(from: self) else { return nil }
+        
+        // Date 객체를 "오전/오후 x시 x분" 형태로 변환
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.setLocalizedDateFormatFromTemplate("ahmm")
+        
+        return formatter.string(from: date)
+    }
+}
+
+
+extension ChatRoomDTO {
+    static var testArray = [
+        ChatRoomDTO(
+            id: "1",
+            profileImage: "urlString",
+            name: "정호윤",
+            latestMessageReceivedTime: "2023-09-04T09:15:30+00:00",
+            latestMessageType: "text",
+            latestMessageContent: "수신된 가장 최근 메시지를 표시합니다.",
+            unreadMessageCount: 0
+        ),
+        ChatRoomDTO(
+            id: "2",
+            profileImage: "urlString",
+            name: "채팅방 2",
+            latestMessageReceivedTime: "2023-09-04T15:45:10+00:00",
+            latestMessageType: "text",
+            latestMessageContent: "수신된 가장 최근 메시지 중 긴 메시지가 어떻게 보여질지에 대한 테스트입니다.",
+            unreadMessageCount: 0
+        ),
+        ChatRoomDTO(
+            id: "3",
+            profileImage: "urlString",
+            name: "채팅방 이름이 길어진 경우에 대한 테스트입니다.",
+            latestMessageReceivedTime: "2023-09-04T11:00:00+00:00",
+            latestMessageType: "image",
+            latestMessageContent: "이미지가 수신된 경우의 미리보기 메시지입니다.",
+            unreadMessageCount: 0
+        ),
+        ChatRoomDTO(
+            id: "4",
+            profileImage: "urlString",
+            name: "채팅방 4",
+            latestMessageReceivedTime: "2023-09-04T19:30:20+00:00",
+            latestMessageType: "text",
+            latestMessageContent: "수신된 가장 최근 메시지를 표시합니다.",
+            unreadMessageCount: 0
+        ),
+        ChatRoomDTO(
+            id: "5",
+            profileImage: "urlString",
+            name: "채팅방 5",
+            latestMessageReceivedTime: "2023-09-04T04:55:55+00:00",
+            latestMessageType: "text",
+            latestMessageContent: "수신된 가장 최근 메시지를 표시합니다.",
+            unreadMessageCount: 0
+        ),
+        ChatRoomDTO(
+            id: "6",
+            profileImage: "urlString",
+            name: "채팅방 6",
+            latestMessageReceivedTime: "2023-09-04T12:34:56+00:00",
+            latestMessageType: "text",
+            latestMessageContent: "수신된 가장 최근 메시지를 표시합니다.",
+            unreadMessageCount: 0
+        )
+    ]
 }

--- a/Bridge/Sources/Data/Network/NetworkService/DefaultNetworkService.swift
+++ b/Bridge/Sources/Data/Network/NetworkService/DefaultNetworkService.swift
@@ -23,8 +23,8 @@ final class DefaultNetworkService: NetworkService {
     func leaveChatRoom(id: String) -> Single<Void> {
         Single.create { single in
             
-            if let index = DefaultNetworkService.chatRoomDTOs.firstIndex(where: { $0.id == id }) {
-                DefaultNetworkService.chatRoomDTOs.remove(at: index)
+            if let index = ChatRoomDTO.testArray.firstIndex(where: { $0.id == id }) {
+                ChatRoomDTO.testArray.remove(at: index)
                 single(.success(()))
             } else {
                 single(.failure(NetworkError.unknown))
@@ -117,19 +117,4 @@ final class DefaultNetworkService: NetworkService {
             )
         ])
     }
-}
-
-// MARK: - For test
-extension DefaultNetworkService {
-    static var chatRoomDTOs = [
-        ChatRoomDTO(
-            id: "1",
-            profileImage: "1",
-            name: "정호윤",
-            latestMessageReceivedTime: "1",
-            latestMessageType: "1",
-            latestMessageContent: "1",
-            unreadMessageCount: 0
-        ),
-    ]
 }

--- a/Bridge/Sources/Data/Network/NetworkService/DefaultNetworkService.swift
+++ b/Bridge/Sources/Data/Network/NetworkService/DefaultNetworkService.swift
@@ -17,7 +17,7 @@ final class DefaultNetworkService: NetworkService {
     
     // MARK: - For test
     func requestTestChatRooms() -> Observable<[ChatRoomDTO]> {
-        Observable.just(DefaultNetworkService.chatRoomDTOs)
+        Observable.just(ChatRoomDTO.testArray)
     }
     
     func leaveChatRoom(id: String) -> Single<Void> {
@@ -124,35 +124,12 @@ extension DefaultNetworkService {
     static var chatRoomDTOs = [
         ChatRoomDTO(
             id: "1",
-            profileImage: nil,
+            profileImage: "1",
             name: "정호윤",
-            time: Date(),
-            messageType: .text,
-            messagePreview: "메시지 미리보기 1"
+            latestMessageReceivedTime: "1",
+            latestMessageType: "1",
+            latestMessageContent: "1",
+            unreadMessageCount: 0
         ),
-        ChatRoomDTO(
-            id: "2",
-            profileImage: nil,
-            name: "엄지호",
-            time: Date(),
-            messageType: .text,
-            messagePreview: "메시지 미리보기 2"
-        ),
-        ChatRoomDTO(
-            id: "3",
-            profileImage: nil,
-            name: "홍길동",
-            time: Date(),
-            messageType: .text,
-            messagePreview: "메시지 미리보기 3"
-        ),
-        ChatRoomDTO(
-            id: "4",
-            profileImage: nil,
-            name: "홍길동",
-            time: Date(),
-            messageType: .text,
-            messagePreview: "메시지 미리보기 4"
-        )
     ]
 }

--- a/Bridge/Sources/Data/Repositories/Chat/DefaultChatRoomRepository.swift
+++ b/Bridge/Sources/Data/Repositories/Chat/DefaultChatRoomRepository.swift
@@ -19,7 +19,7 @@ final class DefaultChatRoomRepository: ChatRoomRepository {
         networkService
             .requestTestChatRooms()
             .map { data -> [ChatRoom] in
-                data.compactMap { $0.toModel() }
+                data.compactMap { $0.toDomain() }
             }
     }
     

--- a/Bridge/Sources/Domain/Entities/Chat/Chat.swift
+++ b/Bridge/Sources/Domain/Entities/Chat/Chat.swift
@@ -20,5 +20,10 @@ struct Chat {
         case opponent
     }
     
+    enum State {
+        case read
+        case unread
+    }
+    
     let content: String
 }

--- a/Bridge/Sources/Domain/Entities/Chat/ChatRoom.swift
+++ b/Bridge/Sources/Domain/Entities/Chat/ChatRoom.swift
@@ -8,23 +8,39 @@
 import Foundation
 
 struct ChatRoom {
+    /// 가장 최근에 수신된 메시지와 관련된 정보를 저장하기 위한 타입
+    struct LatestMessage {
+        let receivedTime: String
+        let type: Chat.MessageType
+        let content: String
+    }
+    
     let id: String
-    let profileImage: URL?
+    let profileImageURL: URL?
+
+    /// 채팅방 이름 (일반적으로 수신자 이름과 동일)
     let name: String
-    let time: Date
-    let messageType: Chat.MessageType
-    let messagePreview: String
+    
+    /// 가장 최근에 수신된 메시지
+    let latestMessage: LatestMessage
+
+    /// 읽지 않은 메시지 개수
+    let unreadMessageCount: Int
 }
 
 extension ChatRoom {
     static let onError = ChatRoom(
         id: UUID().uuidString,
-        profileImage: nil,
-        name: "오류",
-        time: Date(),
-        messageType: .text,
-        messagePreview: "오류가 발생했습니다."
+        profileImageURL: nil,
+        name: "채팅방 이름을 불러올 수 없습니다.",
+        latestMessage: LatestMessage(
+            receivedTime: String(),
+            type: .text,
+            content: "메시지를 불러올 수 없습니다."
+        ),
+        unreadMessageCount: 0
     )
 }
 
 extension ChatRoom: Hashable { }
+extension ChatRoom.LatestMessage: Hashable { }

--- a/Bridge/Sources/Domain/Entities/Chat/ChatRoom.swift
+++ b/Bridge/Sources/Domain/Entities/Chat/ChatRoom.swift
@@ -25,7 +25,7 @@ struct ChatRoom {
     let latestMessage: LatestMessage
 
     /// 읽지 않은 메시지 개수
-    let unreadMessageCount: Int
+    let unreadMessageCount: String
 }
 
 extension ChatRoom {
@@ -38,7 +38,7 @@ extension ChatRoom {
             type: .text,
             content: "메시지를 불러올 수 없습니다."
         ),
-        unreadMessageCount: 0
+        unreadMessageCount: "0"
     )
 }
 

--- a/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomCell.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomCell.swift
@@ -106,8 +106,8 @@ final class ChatRoomCell: BaseTableViewCell {
 // MARK: - Configuration
 extension ChatRoomCell {
     func configureCell(with chatRoom: ChatRoom) {
-        nameLabel.text = chatRoom.sender
-        timeLabel.text = chatRoom.time.formatted()
-        messagePreviewLabel.text = chatRoom.messagePreview
+        nameLabel.text = chatRoom.name
+        timeLabel.text = chatRoom.latestMessage.receivedTime
+        messagePreviewLabel.text = chatRoom.latestMessage.content
     }
 }

--- a/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomCell.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomCell.swift
@@ -31,23 +31,25 @@ final class ChatRoomCell: BaseTableViewCell {
     private let nameLabel: UILabel = {
         let label = UILabel()
         label.font = .boldSystemFont(ofSize: 14)
+        label.lineBreakMode = .byTruncatingTail
         return label
     }()
     
-    private let timeLabel: UILabel = {
+    private let latestMessageReceivedTimeLabel: UILabel = {
         let label = UILabel()
         label.textColor = .systemGray
         label.font = .systemFont(ofSize: 10)
         return label
     }()
     
-    private let messagePreviewLabel: UILabel = {
+    private let latestMessageContentLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 14)
+        label.lineBreakMode = .byTruncatingTail
         return label
     }()
     
-    private let unreadMessagesCountLabel: UILabel = {
+    private let unreadMessageCountLabel: UILabel = {
         let label = UILabel()
         label.backgroundColor = .systemRed
         label.text = "1"
@@ -64,8 +66,8 @@ final class ChatRoomCell: BaseTableViewCell {
         
         profileImageView.image = nil
         nameLabel.text = ""
-        timeLabel.text = ""
-        messagePreviewLabel.text = ""
+        latestMessageReceivedTimeLabel.text = ""
+        latestMessageContentLabel.text = ""
     }
     
     // MARK: - Layouts
@@ -78,17 +80,17 @@ final class ChatRoomCell: BaseTableViewCell {
         chatRoomBackgroundView.flex.direction(.row).alignItems(.center).define { flex in
             flex.addItem(profileImageView).size(44).marginLeft(containeroffset)
             
-            flex.addItem().direction(.column).marginHorizontal(16).define { flex in
+            flex.addItem().direction(.column).width(192).marginHorizontal(16).define { flex in
                 flex.addItem().direction(.row).marginBottom(componentOffset).define { flex in
-                    flex.addItem(nameLabel).grow(1)
+                    flex.addItem(nameLabel).shrink(1)
                     flex.addItem().size(componentOffset)
-                    flex.addItem(timeLabel).shrink(1)
+                    flex.addItem(latestMessageReceivedTimeLabel).grow(1)
                 }
                 
-                flex.addItem(messagePreviewLabel)
+                flex.addItem(latestMessageContentLabel)
             }
             
-            flex.addItem(unreadMessagesCountLabel).size(18).position(.absolute).right(containeroffset)
+            flex.addItem(unreadMessageCountLabel).size(18).position(.absolute).right(containeroffset)
         }
     }
 
@@ -107,7 +109,7 @@ final class ChatRoomCell: BaseTableViewCell {
 extension ChatRoomCell {
     func configureCell(with chatRoom: ChatRoom) {
         nameLabel.text = chatRoom.name
-        timeLabel.text = chatRoom.latestMessage.receivedTime
-        messagePreviewLabel.text = chatRoom.latestMessage.content
+        latestMessageReceivedTimeLabel.text = chatRoom.latestMessage.receivedTime
+        latestMessageContentLabel.text = chatRoom.latestMessage.content
     }
 }

--- a/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomCell.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomCell.swift
@@ -1,5 +1,5 @@
 //
-//  ChatRoomTableViewCell.swift
+//  ChatRoomCell.swift
 //  Bridge
 //
 //  Created by 정호윤 on 2023/08/29.
@@ -106,7 +106,7 @@ final class ChatRoomCell: BaseTableViewCell {
 // MARK: - Configuration
 extension ChatRoomCell {
     func configureCell(with chatRoom: ChatRoom) {
-        nameLabel.text = chatRoom.name
+        nameLabel.text = chatRoom.sender
         timeLabel.text = chatRoom.time.formatted()
         messagePreviewLabel.text = chatRoom.messagePreview
     }

--- a/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomCell.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomCell.swift
@@ -75,10 +75,10 @@ final class ChatRoomCell: BaseTableViewCell {
         contentView.addSubview(chatRoomBackgroundView)
         
         let componentOffset: CGFloat = 8
-        let containeroffset: CGFloat = 24
+        let containerOffset: CGFloat = 24
         
         chatRoomBackgroundView.flex.direction(.row).alignItems(.center).define { flex in
-            flex.addItem(profileImageView).size(44).marginLeft(containeroffset)
+            flex.addItem(profileImageView).size(44).marginLeft(containerOffset)
             
             flex.addItem().direction(.column).width(192).marginHorizontal(16).define { flex in
                 flex.addItem().direction(.row).marginBottom(componentOffset).define { flex in
@@ -90,7 +90,7 @@ final class ChatRoomCell: BaseTableViewCell {
                 flex.addItem(latestMessageContentLabel)
             }
             
-            flex.addItem(unreadMessageCountLabel).size(18).position(.absolute).right(containeroffset)
+            flex.addItem(unreadMessageCountLabel).size(18).position(.absolute).right(containerOffset)
         }
     }
 


### PR DESCRIPTION
## 작업 내용
close #30 
close #31 
- `ChatRoom` 엔티티 수정
- `ChatRoomCell` 수정
- 읽지 않은 메시지 개수에 따른 UI 변경 로직 구현

### 스크린샷
|Before|After|
|---|---|
|<img src = "https://cdn.discordapp.com/attachments/1128678172204994560/1148201496190668801/simulator_screenshot_63CD5928-A6EC-4976-8AF9-B8E3358FA556.png" height = 600>|<img src = "https://github.com/bridge0813/bridge-ios/assets/65343417/af805b25-a0f9-4585-92b5-9fc4c78e2f6f" height = 600>|

## 리뷰 노트
- DTO 쪽은 많이 바뀔것 같으니 굳이 확인 안하셔도 될것 같아요!
- 엔티티랑 셀 파일만 확인하시면 될 듯 합니당