### PR TITLE
Main 뷰 플로팅 버튼 구현

### DIFF
--- a/Bridge/Sources/Presentation/Tab/Main/Coordinator/MainCoordinator.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Coordinator/MainCoordinator.swift
@@ -13,7 +13,7 @@ protocol MainCoordinatorProtocol: Coordinator {
     func connectToProjectFilteringFlow()
     func connectToProjectSearchFlow()
     func connectToProjectDetailFlow()
-    func connectToWriteProjectFlow()
+    func connectToCreateProjectFlow()
 }
 
 final class MainCoordinator: MainCoordinatorProtocol {
@@ -63,5 +63,5 @@ extension MainCoordinator {
     func connectToProjectFilteringFlow() { }
     func connectToProjectSearchFlow() { }
     func connectToProjectDetailFlow() { }
-    func connectToWriteProjectFlow() { }
+    func connectToCreateProjectFlow() { }
 }

--- a/Bridge/Sources/Presentation/Tab/Main/Coordinator/MainCoordinator.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Coordinator/MainCoordinator.swift
@@ -13,7 +13,7 @@ protocol MainCoordinatorProtocol: Coordinator {
     func connectToProjectFilteringFlow()
     func connectToProjectSearchFlow()
     func connectToProjectDetailFlow()
-    func connectToCreateProjectFlow()
+    func connectToWriteProjectFlow()
 }
 
 final class MainCoordinator: MainCoordinatorProtocol {
@@ -63,5 +63,5 @@ extension MainCoordinator {
     func connectToProjectFilteringFlow() { }
     func connectToProjectSearchFlow() { }
     func connectToProjectDetailFlow() { }
-    func connectToCreateProjectFlow() { }
+    func connectToWriteProjectFlow() { }
 }

--- a/Bridge/Sources/Presentation/Tab/Main/Main/HotProjectCollectionViewCell.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/HotProjectCollectionViewCell.swift
@@ -125,6 +125,12 @@ final class HotProjectCollectionViewCell: BaseCollectionViewCell {
         
         projectBackgroundView.pin.all().margin(10)
         projectBackgroundView.flex.layout()
+        /// 그림자를 렌더링할 때, 성능 문제가 있기 때문에 그림자 영역을 미리 그려주어야 함.
+        /// 뷰의 bounds가 레이아웃에 의해 먼저 설정되고 'shadowPath' 를 설정해주어야 하기 때문에 이 위치에 해당.
+        projectBackgroundView.layer.shadowPath = UIBezierPath(
+            roundedRect: projectBackgroundView.bounds,
+            cornerRadius: 10
+        ).cgPath
     }
 }
 

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -65,6 +65,8 @@ final class MainViewController: BaseViewController {
         return button
     }()
     
+    var didInitialLayout = false
+    
     private let viewModel: MainViewModel
     
     typealias DataSource = UICollectionViewDiffableDataSource<MainViewModel.Section, Project>
@@ -90,6 +92,11 @@ final class MainViewController: BaseViewController {
     override func viewDidLayoutSubviews() {
         containerView.pin.all(view.pin.safeArea).marginTop(10)
         containerView.flex.layout()
+        
+        if !didInitialLayout {
+            applyLayout(with: .imageAndText)
+            didInitialLayout = true
+        }
     }
     
     // MARK: - Methods
@@ -284,13 +291,8 @@ extension MainViewController: UICollectionViewDelegate { }
 
 // MARK: - ScrollEvent
 extension MainViewController {
-    enum WriteButtonLayout {
-        case imageAndText
-        case imageOnly
-    }
-
     // MARK: - Button Animation
-    private func animateLayoutChange(to mode: WriteButtonLayout) {
+    private func animateLayoutChange(to mode: MainViewModel.WriteButtonLayout) {
         UIView.animate(withDuration: 0.3) { [weak self] in
             self?.applyLayout(with: mode)
             self?.applyConfiguration(with: mode)
@@ -298,7 +300,7 @@ extension MainViewController {
     }
     
     // MARK: - Button Layout
-    private func applyLayout(with layout: WriteButtonLayout) {
+    private func applyLayout(with layout: MainViewModel.WriteButtonLayout) {
         switch layout {
         case .imageAndText:
             layoutButton(width: 110, height: 50)
@@ -319,7 +321,7 @@ extension MainViewController {
     }
     
     // MARK: - Button Configuration
-    private func applyConfiguration(with layout: WriteButtonLayout) {
+    private func applyConfiguration(with layout: MainViewModel.WriteButtonLayout) {
         switch layout {
         case .imageAndText:
             createProjectButton.configuration = textAndImageConfig()

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -58,19 +58,11 @@ final class MainViewController: BaseViewController {
     
     private let currentLayoutMode = BehaviorRelay<WriteButtonLayout>(value: .imageAndText)
     private lazy var writeProjectButton: UIButton = {
-        let imageConfig = UIImage.SymbolConfiguration(pointSize: 20, weight: .regular, scale: .default)
-        let image = UIImage(systemName: "plus", withConfiguration: imageConfig)
-        var configuration = UIButton.Configuration.tinted()
-        configuration.image = image
-        configuration.imagePlacement = .leading
-        configuration.imagePadding = 5
-        configuration.title = "글쓰기"
-        configuration.attributedTitle?.font = .boldSystemFont(ofSize: 20)
-        
-        let button = UIButton(configuration: configuration)
+        let button = UIButton(configuration: textAndImageConfig())
         button.tintColor = .white
         button.layer.cornerRadius = 23
         button.backgroundColor = .gray
+        button.clipsToBounds = true
         
         return button
     }()
@@ -339,12 +331,12 @@ extension MainViewController {
                 UIView.animate(withDuration: 0.3) {
                     switch mode {
                     case .imageAndText:
-                        owner.writeProjectButton.configuration = self.plusTextConfiguration()
+                        owner.writeProjectButton.configuration = self.textAndImageConfig()
                         owner.writeProjectButton.layer.cornerRadius = 23
                         owner.layoutButton(width: 110, height: 50)
                         
                     case .imageOnly:
-                        owner.writeProjectButton.configuration = self.onlyImageConfiguration()
+                        owner.writeProjectButton.configuration = self.imageOnlyConfig()
                         owner.writeProjectButton.layer.cornerRadius = 30
                         owner.layoutButton(width: 60, height: 60)
                         
@@ -354,24 +346,28 @@ extension MainViewController {
             .disposed(by: disposeBag)
     }
     
-    private func plusTextConfiguration() -> UIButton.Configuration {
+    private func textAndImageConfig() -> UIButton.Configuration {
         let imageConfig = UIImage.SymbolConfiguration(pointSize: 20, weight: .regular, scale: .default)
         let image = UIImage(systemName: "plus", withConfiguration: imageConfig)
+        
         var configuration = UIButton.Configuration.tinted()
         configuration.image = image
         configuration.imagePlacement = .leading
         configuration.imagePadding = 5
         configuration.title = "글쓰기"
         configuration.attributedTitle?.font = .boldSystemFont(ofSize: 20)
+        configuration.baseBackgroundColor = .darkGray
         
         return configuration
     }
     
-    private func onlyImageConfiguration() -> UIButton.Configuration {
+    private func imageOnlyConfig() -> UIButton.Configuration {
         let imageConfig = UIImage.SymbolConfiguration(pointSize: 25, weight: .regular, scale: .default)
         let image = UIImage(systemName: "plus", withConfiguration: imageConfig)
+        
         var configuration = UIButton.Configuration.tinted()
         configuration.image = image
+        configuration.baseBackgroundColor = .darkGray
         
         return configuration
     }

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -56,7 +56,7 @@ final class MainViewController: BaseViewController {
         return searchBar
     }()
     
-    private let currentLayoutMode = BehaviorRelay<LayoutMode>(value: .text)
+    private let currentLayoutMode = BehaviorRelay<WriteButtonLayout>(value: .imageAndText)
     private lazy var writeProjectButton: UIButton = {
         let imageConfig = UIImage.SymbolConfiguration(pointSize: 20, weight: .regular, scale: .default)
         let image = UIImage(systemName: "plus", withConfiguration: imageConfig)
@@ -294,9 +294,27 @@ extension MainViewController: UICollectionViewDelegate { }
 
 // MARK: - ScrollEvent
 extension MainViewController {
-    enum LayoutMode {
-        case text
-        case image
+    enum WriteButtonLayout {
+        case imageAndText
+        case imageOnly
+    }
+
+    private func applyLayout(with layout: WriteButtonLayout) {
+        switch layout {
+        case .imageAndText:
+            layoutButton(width: 110, height: 50)
+            
+        case .imageOnly:
+            layoutButton(width: 60, height: 60)
+        }
+    }
+
+    private func layoutButton(width: CGFloat, height: CGFloat) {
+        writeProjectButton.pin
+            .bottom(view.pin.safeArea.bottom + 15)
+            .right(15)
+            .width(width)
+            .height(height)
     }
     
     private func bindCollectionViewScrollToLayoutMode() {
@@ -306,28 +324,10 @@ extension MainViewController {
             .map { owner, _ in
                 owner.projectCollectionView.contentOffset.y
             }
-            .map { $0 <= 0 ? LayoutMode.text : LayoutMode.image }
+            .map { $0 <= 0 ? WriteButtonLayout.imageAndText : WriteButtonLayout.imageOnly }
             .distinctUntilChanged()
             .bind(to: currentLayoutMode)
             .disposed(by: disposeBag)
-    }
-    
-    private func layoutWriteButton(with mode: LayoutMode) {
-        switch mode {
-        case .text:
-            writeProjectButton.pin
-                .bottom(view.pin.safeArea.bottom + 15)
-                .right(15)
-                .width(110)
-                .height(50)
-            
-        case .image:
-            writeProjectButton.pin
-                .bottom(view.pin.safeArea.bottom + 15)
-                .right(15)
-                .width(60)
-                .height(60)
-        }
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -56,6 +56,24 @@ final class MainViewController: BaseViewController {
         return searchBar
     }()
     
+    private let writeProjectButton: UIButton = {
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 20, weight: .regular, scale: .default)
+        let image = UIImage(systemName: "plus", withConfiguration: imageConfig)
+        var configuration = UIButton.Configuration.tinted()
+        configuration.image = image
+        configuration.imagePlacement = .leading
+        configuration.imagePadding = 5
+        configuration.title = "글쓰기"
+        configuration.attributedTitle?.font = .boldSystemFont(ofSize: 20)
+        
+        let button = UIButton(configuration: configuration)
+        button.tintColor = .white
+        button.layer.cornerRadius = 23
+        button.backgroundColor = .gray
+        
+        return button
+    }()
+    
     private let viewModel: MainViewModel
     
     typealias DataSource = UICollectionViewDiffableDataSource<MainViewModel.Section, Project>
@@ -81,6 +99,11 @@ final class MainViewController: BaseViewController {
     override func viewDidLayoutSubviews() {
         containerView.pin.all(view.pin.safeArea).marginTop(10)
         containerView.flex.layout()
+        writeProjectButton.pin
+            .bottom(view.pin.safeArea.bottom + 15)
+            .right(15)
+            .width(110)
+            .height(50)
     }
     
     // MARK: - Methods
@@ -92,6 +115,7 @@ final class MainViewController: BaseViewController {
     
     override func configureLayouts() {
         view.addSubview(containerView)
+        view.addSubview(writeProjectButton)
         containerView.flex.direction(.column).define { flex in
             /// 상단 메뉴 버튼 및 서치바
             flex.addItem().height(70).direction(.row).justifyContent(.start).alignItems(.stretch).define { flex in

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -56,7 +56,6 @@ final class MainViewController: BaseViewController {
         return searchBar
     }()
     
-    private let currentLayoutMode = BehaviorRelay<WriteButtonLayout>(value: .imageAndText)
     private lazy var createProjectButton: UIButton = {
         let button = UIButton(configuration: textAndImageConfig())
         button.tintColor = .white
@@ -91,7 +90,6 @@ final class MainViewController: BaseViewController {
     override func viewDidLayoutSubviews() {
         containerView.pin.all(view.pin.safeArea).marginTop(10)
         containerView.flex.layout()
-        bindWriteButtonLayoutMode()
     }
     
     // MARK: - Methods
@@ -127,7 +125,7 @@ final class MainViewController: BaseViewController {
             .setDelegate(self)
             .disposed(by: disposeBag)
         
-        bindCollectionViewScrollToLayoutMode()
+        bindCollectionViewScrollToLayoutChange()
         
         let input = MainViewModel.Input(viewDidLoadTrigger: Observable.just(()))
         let output = viewModel.transform(input: input)
@@ -358,7 +356,7 @@ extension MainViewController {
     }
     
     // MARK: - Bind Method
-    private func bindCollectionViewScrollToLayoutMode() {
+    private func bindCollectionViewScrollToLayoutChange() {
         projectCollectionView.rx
             .didScroll
             .withUnretained(self)
@@ -367,16 +365,8 @@ extension MainViewController {
             }
             .map { $0 <= 0 ? WriteButtonLayout.imageAndText : WriteButtonLayout.imageOnly }
             .distinctUntilChanged()
-            .bind(to: currentLayoutMode)
-            .disposed(by: disposeBag)
-    }
-    
-    private func bindWriteButtonLayoutMode() {
-        currentLayoutMode
-            .asObservable()
-            .withUnretained(self)
-            .subscribe(onNext: { owner, mode in
-                owner.animateLayoutChange(to: mode)
+            .subscribe(onNext: { [weak self] mode in
+                self?.animateLayoutChange(to: mode)
             })
             .disposed(by: disposeBag)
     }

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -13,7 +13,7 @@ import RxSwift
 
 final class MainViewController: BaseViewController {
     // MARK: - Properties
-    private let containerView = UIView()
+    private let rootFlexContainer = UIView()
     private lazy var projectCollectionView: UICollectionView = {
         let layout = createCompositionalLayout()
         
@@ -89,12 +89,12 @@ final class MainViewController: BaseViewController {
     }
     
     override func viewDidLayoutSubviews() {
-        containerView.pin.all(view.pin.safeArea).marginTop(10)
-        containerView.flex.layout()
+        rootFlexContainer.pin.all(view.pin.safeArea).marginTop(10)
+        rootFlexContainer.flex.layout()
         
-        if !viewModel.didInitialLayout {
-            applyLayout(with: .imageAndText)
-            viewModel.didInitialLayout = true
+        if !viewModel.isInitialLayout {
+            updateButtonLayout(for: .both)
+            viewModel.isInitialLayout = true
         }
     }
     
@@ -106,9 +106,9 @@ final class MainViewController: BaseViewController {
     }
     
     override func configureLayouts() {
-        view.addSubview(containerView)
+        view.addSubview(rootFlexContainer)
         view.addSubview(createProjectButton)
-        containerView.flex.direction(.column).define { flex in
+        rootFlexContainer.flex.direction(.column).define { flex in
             /// 상단 메뉴 버튼 및 서치바
             flex.addItem().height(70).direction(.row).justifyContent(.start).alignItems(.stretch).define { flex in
                 flex.addItem(filterButton).marginLeft(10)
@@ -132,8 +132,8 @@ final class MainViewController: BaseViewController {
             .disposed(by: disposeBag)
         
         let input = MainViewModel.Input(
-            viewDidLoadTrigger: Observable.just(()),
-            didScrollTriigger: projectCollectionView.rx.contentOffset.asObservable()
+            viewDidLoad: Observable.just(()),
+            didScroll: projectCollectionView.rx.contentOffset.asObservable()
         )
         let output = viewModel.transform(input: input)
         
@@ -298,27 +298,27 @@ extension MainViewController: UICollectionViewDelegate { }
 // MARK: - ScrollEvent
 extension MainViewController {
     // MARK: - Button Animation
-    private func animateLayoutChange(to mode: MainViewModel.WriteButtonLayout) {
+    private func animateLayoutChange(to mode: MainViewModel.CreateButtonDisplayState) {
         UIView.animate(withDuration: 0.3) { [weak self] in
-            self?.applyLayout(with: mode)
+            self?.updateButtonLayout(for: mode)
             self?.applyConfiguration(with: mode)
         }
     }
     
     // MARK: - Button Layout
-    private func applyLayout(with layout: MainViewModel.WriteButtonLayout) {
-        switch layout {
-        case .imageAndText:
-            layoutButton(width: 110, height: 50)
+    private func updateButtonLayout(for state: MainViewModel.CreateButtonDisplayState) {
+        switch state {
+        case .both:
+            layoutCreateButton(width: 110, height: 50)
             createProjectButton.layer.cornerRadius = 23
             
-        case .imageOnly:
-            layoutButton(width: 60, height: 60)
+        case .only:
+            layoutCreateButton(width: 60, height: 60)
             createProjectButton.layer.cornerRadius = 30
         }
     }
     
-    private func layoutButton(width: CGFloat, height: CGFloat) {
+    private func layoutCreateButton(width: CGFloat, height: CGFloat) {
         createProjectButton.pin
             .bottom(view.pin.safeArea.bottom + 15)
             .right(15)
@@ -327,12 +327,12 @@ extension MainViewController {
     }
     
     // MARK: - Button Configuration
-    private func applyConfiguration(with layout: MainViewModel.WriteButtonLayout) {
+    private func applyConfiguration(with layout: MainViewModel.CreateButtonDisplayState) {
         switch layout {
-        case .imageAndText:
+        case .both:
             createProjectButton.configuration = textAndImageConfig()
             
-        case .imageOnly:
+        case .only:
             createProjectButton.configuration = imageOnlyConfig()
         }
     }

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -57,7 +57,7 @@ final class MainViewController: BaseViewController {
     }()
     
     private lazy var createProjectButton: UIButton = {
-        let button = UIButton(configuration: textAndImageConfig())
+        let button = UIButton(configuration: bothConfig())
         button.tintColor = .white
         button.backgroundColor = .gray
         button.clipsToBounds = true
@@ -301,7 +301,7 @@ extension MainViewController {
     private func animateLayoutChange(to mode: MainViewModel.CreateButtonDisplayState) {
         UIView.animate(withDuration: 0.3) { [weak self] in
             self?.updateButtonLayout(for: mode)
-            self?.applyConfiguration(with: mode)
+            self?.updateButtonConfig(for: mode)
         }
     }
     
@@ -327,17 +327,17 @@ extension MainViewController {
     }
     
     // MARK: - Button Configuration
-    private func applyConfiguration(with layout: MainViewModel.CreateButtonDisplayState) {
-        switch layout {
+    private func updateButtonConfig(for state: MainViewModel.CreateButtonDisplayState) {
+        switch state {
         case .both:
-            createProjectButton.configuration = textAndImageConfig()
+            createProjectButton.configuration = createConfigForBoth()
             
         case .only:
-            createProjectButton.configuration = imageOnlyConfig()
+            createProjectButton.configuration = createConfigForOnly()
         }
     }
 
-    private func textAndImageConfig() -> UIButton.Configuration {
+    private func createConfigForBoth() -> UIButton.Configuration {
         let imageConfig = UIImage.SymbolConfiguration(pointSize: 20, weight: .regular, scale: .default)
         let image = UIImage(systemName: "plus", withConfiguration: imageConfig)
     
@@ -352,7 +352,7 @@ extension MainViewController {
         return configuration
     }
     
-    private func imageOnlyConfig() -> UIButton.Configuration {
+    private func createConfigForOnly() -> UIButton.Configuration {
         let imageConfig = UIImage.SymbolConfiguration(pointSize: 25, weight: .regular, scale: .default)
         let image = UIImage(systemName: "plus", withConfiguration: imageConfig)
         

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -65,8 +65,6 @@ final class MainViewController: BaseViewController {
         return button
     }()
     
-    var didInitialLayout = false
-    
     private let viewModel: MainViewModel
     
     typealias DataSource = UICollectionViewDiffableDataSource<MainViewModel.Section, Project>
@@ -94,9 +92,9 @@ final class MainViewController: BaseViewController {
         containerView.pin.all(view.pin.safeArea).marginTop(10)
         containerView.flex.layout()
         
-        if !didInitialLayout {
+        if !viewModel.didInitialLayout {
             applyLayout(with: .imageAndText)
-            didInitialLayout = true
+            viewModel.didInitialLayout = true
         }
     }
     

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -57,10 +57,9 @@ final class MainViewController: BaseViewController {
     }()
     
     private let currentLayoutMode = BehaviorRelay<WriteButtonLayout>(value: .imageAndText)
-    private lazy var writeProjectButton: UIButton = {
+    private lazy var createProjectButton: UIButton = {
         let button = UIButton(configuration: textAndImageConfig())
         button.tintColor = .white
-        button.layer.cornerRadius = 23
         button.backgroundColor = .gray
         button.clipsToBounds = true
         
@@ -104,7 +103,7 @@ final class MainViewController: BaseViewController {
     
     override func configureLayouts() {
         view.addSubview(containerView)
-        view.addSubview(writeProjectButton)
+        view.addSubview(createProjectButton)
         containerView.flex.direction(.column).define { flex in
             /// 상단 메뉴 버튼 및 서치바
             flex.addItem().height(70).direction(.row).justifyContent(.start).alignItems(.stretch).define { flex in
@@ -305,16 +304,16 @@ extension MainViewController {
         switch layout {
         case .imageAndText:
             layoutButton(width: 110, height: 50)
-            writeProjectButton.layer.cornerRadius = 23
+            createProjectButton.layer.cornerRadius = 23
             
         case .imageOnly:
             layoutButton(width: 60, height: 60)
-            writeProjectButton.layer.cornerRadius = 30
+            createProjectButton.layer.cornerRadius = 30
         }
     }
     
     private func layoutButton(width: CGFloat, height: CGFloat) {
-        writeProjectButton.pin
+        createProjectButton.pin
             .bottom(view.pin.safeArea.bottom + 15)
             .right(15)
             .width(width)
@@ -325,17 +324,17 @@ extension MainViewController {
     private func applyConfiguration(with layout: WriteButtonLayout) {
         switch layout {
         case .imageAndText:
-            writeProjectButton.configuration = textAndImageConfig()
+            createProjectButton.configuration = textAndImageConfig()
             
         case .imageOnly:
-            writeProjectButton.configuration = imageOnlyConfig()
+            createProjectButton.configuration = imageOnlyConfig()
         }
     }
 
     private func textAndImageConfig() -> UIButton.Configuration {
         let imageConfig = UIImage.SymbolConfiguration(pointSize: 20, weight: .regular, scale: .default)
         let image = UIImage(systemName: "plus", withConfiguration: imageConfig)
-        
+    
         var configuration = UIButton.Configuration.tinted()
         configuration.image = image
         configuration.imagePlacement = .leading

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -92,6 +92,7 @@ final class MainViewController: BaseViewController {
     override func viewDidLayoutSubviews() {
         containerView.pin.all(view.pin.safeArea).marginTop(10)
         containerView.flex.layout()
+        bindWriteButtonLayoutMode()
     }
     
     // MARK: - Methods
@@ -128,7 +129,6 @@ final class MainViewController: BaseViewController {
             .disposed(by: disposeBag)
         
         bindCollectionViewScrollToLayoutMode()
-        bindWriteButtonLayoutMode()
         
         let input = MainViewModel.Input(viewDidLoadTrigger: Observable.just(()))
         let output = viewModel.transform(input: input)

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -82,6 +82,7 @@ final class MainViewController: BaseViewController {
     // MARK: - Lifecycles
     override func viewDidLoad() {
         super.viewDidLoad()
+        
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -363,5 +364,4 @@ extension MainViewController {
         
         return configuration
     }
-    
 }

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -57,7 +57,7 @@ final class MainViewController: BaseViewController {
     }()
     
     private lazy var createProjectButton: UIButton = {
-        let button = UIButton(configuration: bothConfig())
+        let button = UIButton(configuration: createConfigForBoth())
         button.tintColor = .white
         button.backgroundColor = .gray
         button.clipsToBounds = true
@@ -91,11 +91,6 @@ final class MainViewController: BaseViewController {
     override func viewDidLayoutSubviews() {
         rootFlexContainer.pin.all(view.pin.safeArea).marginTop(10)
         rootFlexContainer.flex.layout()
-        
-        if !viewModel.isInitialLayout {
-            updateButtonLayout(for: .both)
-            viewModel.isInitialLayout = true
-        }
     }
     
     // MARK: - Methods
@@ -107,7 +102,7 @@ final class MainViewController: BaseViewController {
     
     override func configureLayouts() {
         view.addSubview(rootFlexContainer)
-        view.addSubview(createProjectButton)
+        
         rootFlexContainer.flex.direction(.column).define { flex in
             /// 상단 메뉴 버튼 및 서치바
             flex.addItem().height(70).direction(.row).justifyContent(.start).alignItems(.stretch).define { flex in
@@ -117,6 +112,14 @@ final class MainViewController: BaseViewController {
             
             /// 컬렉션 뷰
             flex.addItem(projectCollectionView).grow(1).marginTop(10)
+            
+            flex.addItem(createProjectButton)
+                .cornerRadius(23)
+                .position(.absolute)
+                .right(15)
+                .bottom(15)
+                .width(110)
+                .height(50)
         }
     }
     
@@ -309,21 +312,21 @@ extension MainViewController {
     private func updateButtonLayout(for state: MainViewModel.CreateButtonDisplayState) {
         switch state {
         case .both:
-            layoutCreateButton(width: 110, height: 50)
-            createProjectButton.layer.cornerRadius = 23
+            layoutCreateButton(width: 110, height: 50, radius: 23)
             
         case .only:
-            layoutCreateButton(width: 60, height: 60)
-            createProjectButton.layer.cornerRadius = 30
+            layoutCreateButton(width: 60, height: 60, radius: 30)
         }
     }
     
-    private func layoutCreateButton(width: CGFloat, height: CGFloat) {
-        createProjectButton.pin
-            .bottom(view.pin.safeArea.bottom + 15)
-            .right(15)
+    private func layoutCreateButton(width: CGFloat, height: CGFloat, radius: CGFloat) {
+        createProjectButton.flex
+            .position(.absolute)
+            .cornerRadius(radius)
             .width(width)
             .height(height)
+        
+        rootFlexContainer.flex.layout()
     }
     
     // MARK: - Button Configuration

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -136,6 +136,7 @@ final class MainViewController: BaseViewController {
             .disposed(by: disposeBag)
         
         bindCollectionViewScrollToLayoutMode()
+        bindWriteButtonLayoutMode()
         
         let input = MainViewModel.Input(viewDidLoadTrigger: Observable.just(()))
         let output = viewModel.transform(input: input)
@@ -330,28 +331,27 @@ extension MainViewController {
             .disposed(by: disposeBag)
     }
     
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        if scrollView.contentOffset.y <= 0 {
-            // 최상위에 도달
-            if currentLayoutMode != .text {
-                UIView.animate(withDuration: 0.3) { [weak self] in
-                    self?.writeProjectButton.configuration = self?.plusTextConfiguration()
-                    self?.writeProjectButton.layer.cornerRadius = 23
-                    self?.layoutWriteButton(with: .text)
+    private func bindWriteButtonLayoutMode() {
+        currentLayoutMode
+            .asObservable()
+            .withUnretained(self)
+            .subscribe(onNext: { owner, mode in
+                UIView.animate(withDuration: 0.3) {
+                    switch mode {
+                    case .imageAndText:
+                        owner.writeProjectButton.configuration = self.plusTextConfiguration()
+                        owner.writeProjectButton.layer.cornerRadius = 23
+                        owner.layoutButton(width: 110, height: 50)
+                        
+                    case .imageOnly:
+                        owner.writeProjectButton.configuration = self.onlyImageConfiguration()
+                        owner.writeProjectButton.layer.cornerRadius = 30
+                        owner.layoutButton(width: 60, height: 60)
+                        
+                    }
                 }
-                currentLayoutMode = .text
-            }
-            
-        } else {
-            if currentLayoutMode != .image {
-                UIView.animate(withDuration: 0.3) { [weak self] in
-                    self?.writeProjectButton.configuration = self?.onlyImageConfiguration()
-                    self?.writeProjectButton.layer.cornerRadius = 30
-                    self?.layoutWriteButton(with: .image)
-                }
-                currentLayoutMode = .image
-            }
-        }
+            })
+            .disposed(by: disposeBag)
     }
     
     private func plusTextConfiguration() -> UIButton.Configuration {

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
@@ -73,4 +73,9 @@ extension MainViewModel {
         case hot
         case main
     }
+    
+    enum WriteButtonLayout {
+        case imageAndText
+        case imageOnly
+    }
 }

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
@@ -25,7 +25,6 @@ final class MainViewModel: ViewModelType {
     }
 
     // MARK: - Properties
-    var isInitialLayout = false  // viewDidLayoutSubviews() 내에서 레이아웃 설정 메서드가 딱 한번만 호출되도록
     let disposeBag = DisposeBag()
     private weak var coordinator: MainCoordinator?
     private let fetchProjectsUseCase: FetchAllProjectsUseCase

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
@@ -25,6 +25,7 @@ final class MainViewModel: ViewModelType {
     }
 
     // MARK: - Properties
+    var didInitialLayout = false  // viewDidLayoutSubviews() 내에서 레이아웃 설정 메서드가 딱 한번만 호출되도록
     let disposeBag = DisposeBag()
     private weak var coordinator: MainCoordinator?
     private let fetchProjectsUseCase: FetchAllProjectsUseCase

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
@@ -5,18 +5,23 @@
 //  Created by 엄지호 on 2023/08/30.
 //
 
+import CoreFoundation
+import CoreGraphics
 import RxCocoa
 import RxSwift
 
 final class MainViewModel: ViewModelType {
     // MARK: - Nested Types
     struct Input {
-        var viewDidLoadTrigger: Observable<Void>  // 로그인 여부에 따라, 유저의 분야에 맞게 받아올 정보가 다름(수정 필요)
+        let viewDidLoadTrigger: Observable<Void>  // 로그인 여부에 따라, 유저의 분야에 맞게 받아올 정보가 다름(수정 필요)
+        let didScrollTriigger: Observable<CGPoint>
+        
     }
     
     struct Output {
-        var hotProjects: Driver<[Project]>
-        var projects: Driver<[Project]>
+        let hotProjects: Driver<[Project]>
+        let projects: Driver<[Project]>
+        let layoutMode: Driver<WriteButtonLayout>
     }
 
     // MARK: - Properties
@@ -57,9 +62,15 @@ final class MainViewModel: ViewModelType {
             .bind(to: projects)
             .disposed(by: disposeBag)
         
+        let layoutMode = input.didScrollTriigger
+            .map { $0.y <= 0 ? WriteButtonLayout.imageAndText : .imageOnly}
+            .distinctUntilChanged()
+            .asDriver(onErrorJustReturn: .imageAndText)
+        
         return Output(
             hotProjects: hotProjects.asDriver(onErrorJustReturn: [Project.onError]),
-            projects: projects.asDriver(onErrorJustReturn: [Project.onError])
+            projects: projects.asDriver(onErrorJustReturn: [Project.onError]),
+            layoutMode: layoutMode
         )
     }
 

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
@@ -63,7 +63,7 @@ final class MainViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         let layoutMode = input.didScrollTriigger
-            .map { $0.y <= 0 ? WriteButtonLayout.imageAndText : .imageOnly}
+            .map { $0.y <= 0 ? WriteButtonLayout.imageAndText : .imageOnly }
             .distinctUntilChanged()
             .asDriver(onErrorJustReturn: .imageAndText)
         
@@ -78,7 +78,7 @@ final class MainViewModel: ViewModelType {
 
 // MARK: - Coordinator
 
-// MARK: - Data Section
+// MARK: - UI DataSource
 extension MainViewModel {
     enum Section: CaseIterable {
         case hot

--- a/Bridge/Sources/Presentation/Tab/Main/Main/ProjectCollectionViewCell.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/ProjectCollectionViewCell.swift
@@ -171,6 +171,10 @@ final class ProjectCollectionViewCell: BaseCollectionViewCell {
         
         projectBackgroundView.pin.all().margin(10)
         projectBackgroundView.flex.layout()
+        projectBackgroundView.layer.shadowPath = UIBezierPath(
+            roundedRect: projectBackgroundView.bounds,
+            cornerRadius: 10
+        ).cgPath
     }
 }
 


### PR DESCRIPTION
## 작업 내용
- close #37 

## 스크린샷
https://github.com/bridge0813/bridge-ios/assets/99619107/45c7087c-9f51-4259-bc89-4712cbab669d

## 추가 설명
- 컬렉션 뷰의 스크롤을 바인딩하여 레이아웃 모드를 변경하고, 
- 레이아웃 모드를 바인딩하여 UI를 변경합니다.

## 리뷰 노트
- 플로팅 버튼의 레이아웃은 `viewDidLayoutSubviews` 메서드 내에서 설정되어야 합니다. 
- `viewDidLoad()` 내에서 호출하는 `bind()` 메서드에 바인딩 로직을 넣어두면, 버튼이 화면에 표시되지 않습니다.
- `viewDidLayoutSubviews` 내부에서만 버튼 레이아웃을 설정하는 방법도 시도해 보았으나, 버튼이 화면에는 나타나지만 스크롤에 따라 크기가 변경되지 않았습니다.
- 결국, `viewDidLayoutSubviews`에서 바인딩 로직을 호출하여 문제를 해결하였습니다.

