### PR TITLE
채팅방 목록 화면 내비게이션 바 디자인 수정

### DIFF
--- a/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewController.swift
@@ -51,7 +51,8 @@ final class ChatRoomListViewController: BaseViewController {
     }
     
     private func configureNavigationController() {
-        navigationItem.titleView = NavigationTitleView(title: "채팅")
+        let navigationTitleView = NavigationTitleView(title: "채팅")
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: navigationTitleView)
     }
     
     override func configureLayouts() {

--- a/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewController.swift
@@ -53,6 +53,12 @@ final class ChatRoomListViewController: BaseViewController {
     private func configureNavigationController() {
         let navigationTitleView = NavigationTitleView(title: "채팅")
         navigationItem.leftBarButtonItem = UIBarButtonItem(customView: navigationTitleView)
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            image: UIImage(systemName: "bell"),
+            style: .plain,
+            target: self,
+            action: nil
+        )
     }
     
     override func configureLayouts() {

--- a/Bridge/Sources/Presentation/Tab/Coordinator/TabBarCoordinator.swift
+++ b/Bridge/Sources/Presentation/Tab/Coordinator/TabBarCoordinator.swift
@@ -104,9 +104,7 @@ private extension TabBarCoordinator {
     func configureBarAppearance() {
         let navigationBarAppearance = UINavigationBarAppearance()
         navigationBarAppearance.configureWithOpaqueBackground()
-        navigationBarAppearance.titleTextAttributes = [.foregroundColor: UIColor.black]
-        navigationBarAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.black]
-        navigationBarAppearance.buttonAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.black]
+        UINavigationBar.appearance().tintColor = .black
         UINavigationBar.appearance().standardAppearance = navigationBarAppearance
         UINavigationBar.appearance().scrollEdgeAppearance = navigationBarAppearance
         UINavigationBar.appearance().compactAppearance = navigationBarAppearance


### PR DESCRIPTION
## 작업 내용
#38 
- "채팅" 내비게이션 타이틀 뷰는 title view가 아니라 navigation left bar button item으로 넣어 레이아웃 문제를 해결했습니다.

## 스크린샷
<img src = "https://github.com/bridge0813/bridge-ios/assets/65343417/98772f63-7c59-4213-9092-f6f20a1c4bf3" height = 600>

## 리뷰 노트
- 로그에 찍히는 오류도 수정해보려 했으나, 지금 당장은 어떤 것이 문제인지 파악하기도 힘들고 작동에는 문제가 없어보여 나중에 다시 확인해볼것 같습니다.
