### PR TITLE
Main 뷰 UI 바인딩

### DIFF
--- a/Bridge/Sources/Presentation/Tab/Main/Coordinator/MainCoordinator.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Coordinator/MainCoordinator.swift
@@ -75,5 +75,7 @@ extension MainCoordinator {
         print(project.title)
     }
     
-    func connectToCreateProjectFlow() { }
+    func connectToCreateProjectFlow() {
+        print("모집글 작성 뷰 이동")
+    }
 }

--- a/Bridge/Sources/Presentation/Tab/Main/Coordinator/MainCoordinator.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Coordinator/MainCoordinator.swift
@@ -12,7 +12,7 @@ protocol MainCoordinatorProtocol: Coordinator {
     func connectToNotificationFlow()
     func connectToProjectFilteringFlow()
     func connectToProjectSearchFlow(with query: String)
-    func connectToProjectDetailFlow(with project: Project)
+    func connectToProjectDetailFlow(with id: String)
     func connectToCreateProjectFlow()
 }
 
@@ -71,8 +71,8 @@ extension MainCoordinator {
         print(query)
     }
     
-    func connectToProjectDetailFlow(with project: Project) {
-        print(project.title)
+    func connectToProjectDetailFlow(with id: String) {
+        print(id)
     }
     
     func connectToCreateProjectFlow() {

--- a/Bridge/Sources/Presentation/Tab/Main/Coordinator/MainCoordinator.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Coordinator/MainCoordinator.swift
@@ -62,7 +62,9 @@ extension MainCoordinator {
     func connectToNotificationFlow() {
         print("알림 뷰 이동")
     }
-    func connectToProjectFilteringFlow() { }
+    func connectToProjectFilteringFlow() {
+        print("필터 뷰 이동")
+    }
     func connectToProjectSearchFlow() { }
     func connectToProjectDetailFlow() { }
     func connectToCreateProjectFlow() { }

--- a/Bridge/Sources/Presentation/Tab/Main/Coordinator/MainCoordinator.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Coordinator/MainCoordinator.swift
@@ -12,7 +12,7 @@ protocol MainCoordinatorProtocol: Coordinator {
     func connectToNotificationFlow()
     func connectToProjectFilteringFlow()
     func connectToProjectSearchFlow(with query: String)
-    func connectToProjectDetailFlow()
+    func connectToProjectDetailFlow(with project: Project)
     func connectToCreateProjectFlow()
 }
 
@@ -62,12 +62,18 @@ extension MainCoordinator {
     func connectToNotificationFlow() {
         print("알림 뷰 이동")
     }
+    
     func connectToProjectFilteringFlow() {
         print("필터 뷰 이동")
     }
+    
     func connectToProjectSearchFlow(with query: String) {
         print(query)
     }
-    func connectToProjectDetailFlow() { }
+    
+    func connectToProjectDetailFlow(with project: Project) {
+        print(project.title)
+    }
+    
     func connectToCreateProjectFlow() { }
 }

--- a/Bridge/Sources/Presentation/Tab/Main/Coordinator/MainCoordinator.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Coordinator/MainCoordinator.swift
@@ -11,7 +11,7 @@ import UIKit
 protocol MainCoordinatorProtocol: Coordinator {
     func connectToNotificationFlow()
     func connectToProjectFilteringFlow()
-    func connectToProjectSearchFlow()
+    func connectToProjectSearchFlow(with query: String)
     func connectToProjectDetailFlow()
     func connectToCreateProjectFlow()
 }
@@ -65,7 +65,9 @@ extension MainCoordinator {
     func connectToProjectFilteringFlow() {
         print("필터 뷰 이동")
     }
-    func connectToProjectSearchFlow() { }
+    func connectToProjectSearchFlow(with query: String) {
+        print(query)
+    }
     func connectToProjectDetailFlow() { }
     func connectToCreateProjectFlow() { }
 }

--- a/Bridge/Sources/Presentation/Tab/Main/Coordinator/MainCoordinator.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Coordinator/MainCoordinator.swift
@@ -59,7 +59,9 @@ extension MainCoordinator {
 
 // MARK: - MainCoordinatorProtocol Method
 extension MainCoordinator {
-    func connectToNotificationFlow() { }
+    func connectToNotificationFlow() {
+        print("알림 뷰 이동")
+    }
     func connectToProjectFilteringFlow() { }
     func connectToProjectSearchFlow() { }
     func connectToProjectDetailFlow() { }

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -137,7 +137,8 @@ final class MainViewController: BaseViewController {
         let input = MainViewModel.Input(
             viewDidLoad: Observable.just(()),
             didScroll: projectCollectionView.rx.contentOffset.asObservable(),
-            notificationTap: goToNotificationButton.rx.tap.asObservable()
+            notificationTap: goToNotificationButton.rx.tap.asObservable(),
+            filterTap: filterButton.rx.tap.asObservable()
         )
         let output = viewModel.transform(input: input)
         

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -131,7 +131,7 @@ final class MainViewController: BaseViewController {
     
     override func bind() {
         let input = MainViewModel.Input(
-            viewWillAppear: self.rx.viewWillAppear.asObservable(),
+            viewWillAppear: self.rx.viewWillAppear.asObservable().share(),
             didScroll: projectCollectionView.rx.contentOffset.asObservable(),
             notificationButtonTapped: goToNotificationButton.rx.tap.asObservable(),
             filterButtonTapped: filterButton.rx.tap.asObservable(),

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -135,7 +135,8 @@ final class MainViewController: BaseViewController {
             didScroll: projectCollectionView.rx.contentOffset.asObservable(),
             notificationTap: goToNotificationButton.rx.tap.asObservable(),
             filterTap: filterButton.rx.tap.asObservable(),
-            searchTap: searchBar.rx.searchButtonClicked.withLatestFrom(searchBar.rx.text)
+            searchTap: searchBar.rx.searchButtonClicked.withLatestFrom(searchBar.rx.text),
+            itemSelected: projectCollectionView.rx.itemSelected.asObservable()
         )
         let output = viewModel.transform(input: input)
         

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -136,7 +136,8 @@ final class MainViewController: BaseViewController {
             notificationTap: goToNotificationButton.rx.tap.asObservable(),
             filterTap: filterButton.rx.tap.asObservable(),
             searchTap: searchBar.rx.searchButtonClicked.withLatestFrom(searchBar.rx.text),
-            itemSelected: projectCollectionView.rx.itemSelected.asObservable()
+            itemSelected: projectCollectionView.rx.itemSelected.asObservable(),
+            createTap: createProjectButton.rx.tap.asObservable()
         )
         let output = viewModel.transform(input: input)
         

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -136,7 +136,8 @@ final class MainViewController: BaseViewController {
         
         let input = MainViewModel.Input(
             viewDidLoad: Observable.just(()),
-            didScroll: projectCollectionView.rx.contentOffset.asObservable()
+            didScroll: projectCollectionView.rx.contentOffset.asObservable(),
+            notificationTap: goToNotificationButton.rx.tap.asObservable()
         )
         let output = viewModel.transform(input: input)
         

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -130,15 +130,12 @@ final class MainViewController: BaseViewController {
     }
     
     override func bind() {
-        projectCollectionView.rx
-            .setDelegate(self)
-            .disposed(by: disposeBag)
-        
         let input = MainViewModel.Input(
             viewDidLoad: Observable.just(()),
             didScroll: projectCollectionView.rx.contentOffset.asObservable(),
             notificationTap: goToNotificationButton.rx.tap.asObservable(),
-            filterTap: filterButton.rx.tap.asObservable()
+            filterTap: filterButton.rx.tap.asObservable(),
+            searchTap: searchBar.rx.searchButtonClicked.withLatestFrom(searchBar.rx.text)
         )
         let output = viewModel.transform(input: input)
         
@@ -158,6 +155,10 @@ final class MainViewController: BaseViewController {
             .drive(onNext: { [weak self] mode in
                 self?.animateLayoutChange(to: mode)
             })
+            .disposed(by: disposeBag)
+        
+        projectCollectionView.rx
+            .setDelegate(self)
             .disposed(by: disposeBag)
     }
 }

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -131,7 +131,7 @@ final class MainViewController: BaseViewController {
     
     override func bind() {
         let input = MainViewModel.Input(
-            viewWillAppear: self.rx.viewWillAppear.asObservable().share(),
+            viewWillAppear: self.rx.viewWillAppear.asObservable(),
             didScroll: projectCollectionView.rx.contentOffset.asObservable(),
             notificationButtonTapped: goToNotificationButton.rx.tap.asObservable(),
             filterButtonTapped: filterButton.rx.tap.asObservable(),

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -131,13 +131,13 @@ final class MainViewController: BaseViewController {
     
     override func bind() {
         let input = MainViewModel.Input(
-            viewDidLoad: Observable.just(()),
+            viewWillAppear: self.rx.viewWillAppear.asObservable(),
             didScroll: projectCollectionView.rx.contentOffset.asObservable(),
-            notifButtonDidTap: goToNotificationButton.rx.tap.asObservable(),
-            filterButtonDidTap: filterButton.rx.tap.asObservable(),
-            searchButtonDidTap: searchBar.rx.searchButtonClicked.withLatestFrom(searchBar.rx.text),
+            notificationButtonTapped: goToNotificationButton.rx.tap.asObservable(),
+            filterButtonTapped: filterButton.rx.tap.asObservable(),
+            searchButtonTapped: searchBar.rx.searchButtonClicked.withLatestFrom(searchBar.rx.text),
             itemSelected: projectCollectionView.rx.itemSelected.asObservable(),
-            createButtonDidTap: createProjectButton.rx.tap.asObservable()
+            createButtonTapped: createProjectButton.rx.tap.asObservable()
         )
         let output = viewModel.transform(input: input)
         
@@ -157,10 +157,6 @@ final class MainViewController: BaseViewController {
             .drive(onNext: { [weak self] mode in
                 self?.animateLayoutChange(to: mode)
             })
-            .disposed(by: disposeBag)
-        
-        projectCollectionView.rx
-            .setDelegate(self)
             .disposed(by: disposeBag)
     }
 }
@@ -299,9 +295,6 @@ extension MainViewController {
         dataSource?.apply(snapshot, to: section)
     }
 }
-
-// MARK: - UICollectionViewDelegate
-extension MainViewController: UICollectionViewDelegate { }
 
 // MARK: - ScrollEvent
 extension MainViewController {

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewController.swift
@@ -133,11 +133,11 @@ final class MainViewController: BaseViewController {
         let input = MainViewModel.Input(
             viewDidLoad: Observable.just(()),
             didScroll: projectCollectionView.rx.contentOffset.asObservable(),
-            notificationTap: goToNotificationButton.rx.tap.asObservable(),
-            filterTap: filterButton.rx.tap.asObservable(),
-            searchTap: searchBar.rx.searchButtonClicked.withLatestFrom(searchBar.rx.text),
+            notifButtonDidTap: goToNotificationButton.rx.tap.asObservable(),
+            filterButtonDidTap: filterButton.rx.tap.asObservable(),
+            searchButtonDidTap: searchBar.rx.searchButtonClicked.withLatestFrom(searchBar.rx.text),
             itemSelected: projectCollectionView.rx.itemSelected.asObservable(),
-            createTap: createProjectButton.rx.tap.asObservable()
+            createButtonDidTap: createProjectButton.rx.tap.asObservable()
         )
         let output = viewModel.transform(input: input)
         

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
@@ -18,6 +18,7 @@ final class MainViewModel: ViewModelType {
         let filterTap: Observable<Void>
         let searchTap: Observable<String?>
         let itemSelected: Observable<IndexPath>
+        let createTap: Observable<Void>
     }
     
     struct Output {
@@ -99,6 +100,13 @@ final class MainViewModel: ViewModelType {
                     hotProjects: hotProjects.value,
                     mainProjects: projects.value
                 )
+            })
+            .disposed(by: disposeBag)
+        
+        input.createTap
+            .withUnretained(self)
+            .subscribe(onNext: { owner, _ in
+                owner.coordinator?.connectToCreateProjectFlow()
             })
             .disposed(by: disposeBag)
         

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
@@ -17,6 +17,7 @@ final class MainViewModel: ViewModelType {
         let didScroll: Observable<CGPoint>
         let notificationTap: Observable<Void>
         let filterTap: Observable<Void>
+        let searchTap: Observable<String?>
     }
     
     struct Output {
@@ -79,6 +80,14 @@ final class MainViewModel: ViewModelType {
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
                 owner.coordinator?.connectToProjectFilteringFlow()
+            })
+            .disposed(by: disposeBag)
+        
+        input.searchTap
+            .withUnretained(self)
+            .subscribe(onNext: { owner, text in
+                guard let text else { return }
+                owner.coordinator?.connectToProjectSearchFlow(with: text)
             })
             .disposed(by: disposeBag)
         

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
@@ -14,11 +14,11 @@ final class MainViewModel: ViewModelType {
     struct Input {
         let viewDidLoad: Observable<Void>  // 로그인 여부에 따라, 유저의 분야에 맞게 받아올 정보가 다름(수정 필요)
         let didScroll: Observable<CGPoint>
-        let notificationTap: Observable<Void>
-        let filterTap: Observable<Void>
-        let searchTap: Observable<String?>
+        let notifButtonDidTap: Observable<Void>
+        let filterButtonDidTap: Observable<Void>
+        let searchButtonDidTap: Observable<String?>
         let itemSelected: Observable<IndexPath>
-        let createTap: Observable<Void>
+        let createButtonDidTap: Observable<Void>
     }
     
     struct Output {
@@ -70,21 +70,21 @@ final class MainViewModel: ViewModelType {
             .distinctUntilChanged()
             .asDriver(onErrorJustReturn: .both)
         
-        input.notificationTap
+        input.notifButtonDidTap
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
                 owner.coordinator?.connectToNotificationFlow()
             })
             .disposed(by: disposeBag)
         
-        input.filterTap
+        input.filterButtonDidTap
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
                 owner.coordinator?.connectToProjectFilteringFlow()
             })
             .disposed(by: disposeBag)
         
-        input.searchTap
+        input.searchButtonDidTap
             .withUnretained(self)
             .subscribe(onNext: { owner, text in
                 guard let text else { return }
@@ -103,7 +103,7 @@ final class MainViewModel: ViewModelType {
             })
             .disposed(by: disposeBag)
         
-        input.createTap
+        input.createButtonDidTap
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
                 owner.coordinator?.connectToCreateProjectFlow()

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
@@ -65,10 +65,7 @@ final class MainViewModel: ViewModelType {
             .bind(to: projects)
             .disposed(by: disposeBag)
         
-        let layoutMode = input.didScroll
-            .map { $0.y <= 0 ? CreateButtonDisplayState.both : .only }
-            .distinctUntilChanged()
-            .asDriver(onErrorJustReturn: .both)
+        let layoutMode = calculateButtonState(from: input)
         
         input.notifButtonDidTap
             .withUnretained(self)
@@ -150,5 +147,15 @@ extension MainViewModel {
     enum CreateButtonDisplayState {
         case both
         case only
+    }
+}
+
+// MARK: - Binding
+extension MainViewModel {
+    private func calculateButtonState(from input: Input) -> Driver<CreateButtonDisplayState> {
+        return input.didScroll
+            .map { $0.y <= 0 ? CreateButtonDisplayState.both : .only }
+            .distinctUntilChanged()
+            .asDriver(onErrorJustReturn: .both)
     }
 }

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
@@ -16,6 +16,7 @@ final class MainViewModel: ViewModelType {
         let viewDidLoad: Observable<Void>  // 로그인 여부에 따라, 유저의 분야에 맞게 받아올 정보가 다름(수정 필요)
         let didScroll: Observable<CGPoint>
         let notificationTap: Observable<Void>
+        let filterTap: Observable<Void>
     }
     
     struct Output {
@@ -71,6 +72,13 @@ final class MainViewModel: ViewModelType {
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
                 owner.coordinator?.connectToNotificationFlow()
+            })
+            .disposed(by: disposeBag)
+        
+        input.filterTap
+            .withUnretained(self)
+            .subscribe(onNext: { owner, _ in
+                owner.coordinator?.connectToProjectFilteringFlow()
             })
             .disposed(by: disposeBag)
         

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
@@ -5,8 +5,7 @@
 //  Created by 엄지호 on 2023/08/30.
 //
 
-import CoreFoundation
-import CoreGraphics
+import Foundation
 import RxCocoa
 import RxSwift
 
@@ -18,6 +17,7 @@ final class MainViewModel: ViewModelType {
         let notificationTap: Observable<Void>
         let filterTap: Observable<Void>
         let searchTap: Observable<String?>
+        let itemSelected: Observable<IndexPath>
     }
     
     struct Output {
@@ -91,6 +91,17 @@ final class MainViewModel: ViewModelType {
             })
             .disposed(by: disposeBag)
         
+        input.itemSelected
+            .withUnretained(self)
+            .subscribe(onNext: { owner, indexPath in
+                owner.showProjectDetail(
+                    from: indexPath,
+                    hotProjects: hotProjects.value,
+                    mainProjects: projects.value
+                )
+            })
+            .disposed(by: disposeBag)
+        
         return Output(
             hotProjects: hotProjects.asDriver(onErrorJustReturn: [Project.onError]),
             projects: projects.asDriver(onErrorJustReturn: [Project.onError]),
@@ -102,8 +113,25 @@ final class MainViewModel: ViewModelType {
 
 // MARK: - Coordinator
 extension MainViewModel {
-    
+    private func showProjectDetail(
+        from indexPath: IndexPath,
+        hotProjects: [Project],
+        mainProjects: [Project]
+    ) {
+        let section = Section.allCases[indexPath.section]
+        
+        switch section {
+        case .hot:
+            let project = hotProjects[indexPath.row]
+            coordinator?.connectToProjectDetailFlow(with: project)
+            
+        case .main:
+            let project = mainProjects[indexPath.row]
+            coordinator?.connectToProjectDetailFlow(with: project)
+        }
+    }
 }
+
 // MARK: - UI DataSource
 extension MainViewModel {
     enum Section: CaseIterable {

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
@@ -46,6 +46,7 @@ final class MainViewModel: ViewModelType {
     
     // MARK: - Methods
     func transform(input: Input) -> Output {
+        // MARK: - Fetch Projects
         let hotProjects = input.viewWillAppear
             .withUnretained(self)
             .flatMap { owner, _ in
@@ -60,10 +61,12 @@ final class MainViewModel: ViewModelType {
             }
             .share(replay: 1)
         
+        // MARK: - Button State
         let layoutMode = input.didScroll
             .map { $0.y <= 0 ? CreateButtonDisplayState.both : .only }
             .distinctUntilChanged()
         
+        // MARK: - Button Actions
         input.notificationButtonTapped
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
@@ -93,6 +96,7 @@ final class MainViewModel: ViewModelType {
             })
             .disposed(by: disposeBag)
         
+        // MARK: - Item Selected
         input.itemSelected
             .withUnretained(self)
             .flatMap { owner, indexPath -> Observable<Project> in

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
@@ -12,13 +12,13 @@ import RxSwift
 final class MainViewModel: ViewModelType {
     // MARK: - Nested Types
     struct Input {
-        let viewDidLoad: Observable<Void>  // 로그인 여부에 따라, 유저의 분야에 맞게 받아올 정보가 다름(수정 필요)
+        let viewWillAppear: Observable<Bool>  // 로그인 여부에 따라, 유저의 분야에 맞게 받아올 정보가 다름(수정 필요)
         let didScroll: Observable<CGPoint>
-        let notifButtonDidTap: Observable<Void>
-        let filterButtonDidTap: Observable<Void>
-        let searchButtonDidTap: Observable<String?>
+        let notificationButtonTapped: Observable<Void>
+        let filterButtonTapped: Observable<Void>
+        let searchButtonTapped: Observable<String?>
         let itemSelected: Observable<IndexPath>
-        let createButtonDidTap: Observable<Void>
+        let createButtonTapped: Observable<Void>
     }
     
     struct Output {
@@ -103,7 +103,7 @@ extension MainViewModel {
     private func bindHotProjects(from input: Input) -> BehaviorRelay<[Project]> {
         let hotProjects = BehaviorRelay<[Project]>(value: [])
         
-        input.viewDidLoad
+        input.viewWillAppear
             .withUnretained(self)
             .flatMap { owner, _ in
                 owner.fetchHotProjectsUseCase.execute()
@@ -117,7 +117,7 @@ extension MainViewModel {
     private func bindMainProjects(from input: Input) -> BehaviorRelay<[Project]> {
         let projects = BehaviorRelay<[Project]>(value: [])
         
-        input.viewDidLoad
+        input.viewWillAppear
             .withUnretained(self)
             .flatMap { owner, _ in
                 owner.fetchProjectsUseCase.execute()
@@ -135,7 +135,7 @@ extension MainViewModel {
     }
     
     private func bindNotifButtonDidTap(from input: Input) {
-        input.notifButtonDidTap
+        input.notificationButtonTapped
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
                 owner.coordinator?.connectToNotificationFlow()
@@ -144,7 +144,7 @@ extension MainViewModel {
     }
     
     private func bindFilterButtonDidTap(from input: Input) {
-        input.filterButtonDidTap
+        input.filterButtonTapped
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
                 owner.coordinator?.connectToProjectFilteringFlow()
@@ -153,7 +153,7 @@ extension MainViewModel {
     }
     
     private func bindSearchButtonDidTap(from input: Input) {
-        input.searchButtonDidTap
+        input.searchButtonTapped
             .withUnretained(self)
             .subscribe(onNext: { owner, text in
                 guard let text else { return }
@@ -163,7 +163,7 @@ extension MainViewModel {
     }
     
     private func bindCreateButtonDidTap(from input: Input) {
-        input.createButtonDidTap
+        input.createButtonTapped
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in
                 owner.coordinator?.connectToCreateProjectFlow()

--- a/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
+++ b/Bridge/Sources/Presentation/Tab/Main/Main/MainViewModel.swift
@@ -15,7 +15,7 @@ final class MainViewModel: ViewModelType {
     struct Input {
         let viewDidLoad: Observable<Void>  // 로그인 여부에 따라, 유저의 분야에 맞게 받아올 정보가 다름(수정 필요)
         let didScroll: Observable<CGPoint>
-        
+        let notificationTap: Observable<Void>
     }
     
     struct Output {
@@ -67,6 +67,13 @@ final class MainViewModel: ViewModelType {
             .distinctUntilChanged()
             .asDriver(onErrorJustReturn: .both)
         
+        input.notificationTap
+            .withUnretained(self)
+            .subscribe(onNext: { owner, _ in
+                owner.coordinator?.connectToNotificationFlow()
+            })
+            .disposed(by: disposeBag)
+        
         return Output(
             hotProjects: hotProjects.asDriver(onErrorJustReturn: [Project.onError]),
             projects: projects.asDriver(onErrorJustReturn: [Project.onError]),
@@ -77,7 +84,9 @@ final class MainViewModel: ViewModelType {
 }
 
 // MARK: - Coordinator
-
+extension MainViewModel {
+    
+}
 // MARK: - UI DataSource
 extension MainViewModel {
     enum Section: CaseIterable {


### PR DESCRIPTION
## 작업 내용
- close #41 

## 추가 설명
- 유저와 상호작용하는 각 UI의 이벤트에 대해 바인딩을 진행했습니다.
- 프로젝트 데이터를 가져오는 시점을 viewWillAppear로 변경했습니다. 

## 리뷰 노트
- 목적: itemSelected에서 트리거가 발생하면 hotProjects, projects, 그리고 indexPath를 참조하여 어떤 아이템이 선택되었는지 확인하고, 선택된 아이템의 id를 전달하는 것.

- 변경 시도: 데이터의 타입을 BehaviorRelay에서 Observable로 변경.

- 문제:
Observable을 사용할 경우, hotProjects나 projects에 대한 구독이 필요했고, 이로 인해 cold Observable 형태로 바뀌어 여러 번의 네트워킹 호출이 발생하는 비효율적인 상황이 발생.

이를 해결하기 위해 share()를 사용하여 cold Observable을 hot Observable로 전환하려 했으나, 예상한 대로 동작하지 않는 문제가 발생.

해당 문제는 itemSelected가 트리거될 때, flatMap을 통해 선택된 데이터를 가져와야 하는데, 이 때 debug()를 사용하여 확인했을 때 결과가 출력되지 않았다. 실제로는 viewWillAppear가 트리거될 때만 flatMap의 결과와 subscribe 내부의 코드가 실행되었다.

- 유추된 문제 원인:
바인딩이 이루어지는 시점(viewDidLoad)과 데이터가 실제로 들어오는 시점(viewWillAppear) 사이에 차이가 발생하므로, 초기 바인딩 시점에서는 flatMap이 참조하는 데이터가 아직 존재하지 않아 로직이 수행되지 않았다. 하지만 이 문제는 데이터가 들어있는 상황에서는 로직이 올바르게 수행되어야 하는데, 똑같이 viewWillAppear가 트리거 될 때만, item들을 출력하고 있음.

