### PR TITLE
읽지 않은 메시지 개수 레이블 디자인 수정

### DIFF
--- a/Bridge/Sources/Data/Network/DTOs/Chat/ChatRoomDTO.swift
+++ b/Bridge/Sources/Data/Network/DTOs/Chat/ChatRoomDTO.swift
@@ -68,7 +68,7 @@ extension ChatRoomDTO {
             latestMessageReceivedTime: "2023-09-04T15:45:10+00:00",
             latestMessageType: "text",
             latestMessageContent: "수신된 가장 최근 메시지를 표시합니다.",
-            unreadMessageCount: "100"
+            unreadMessageCount: "10"
         ),
         ChatRoomDTO(
             id: "3",
@@ -77,7 +77,7 @@ extension ChatRoomDTO {
             latestMessageReceivedTime: "2023-09-04T11:00:00+00:00",
             latestMessageType: "image",
             latestMessageContent: "이미지가 수신된 경우의 미리보기 메시지입니다.",
-            unreadMessageCount: "3"
+            unreadMessageCount: "1000"
         ),
         ChatRoomDTO(
             id: "4",

--- a/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomCell.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomCell.swift
@@ -122,7 +122,7 @@ private extension ChatRoomCell {
         unreadMessageCountLabel.text = displayState.text
         
         let size = displayState.size(of: unreadMessageCountLabel.font)
-        let width = max(size.width + 6, 18)
+        let width = max(size.width + 12, 18)
         unreadMessageCountLabel.flex.width(width).height(18).cornerRadius(9)
     }
     
@@ -131,7 +131,7 @@ private extension ChatRoomCell {
         case general(Int)
         case exceededLimit(Int)
         
-        init(_ unreadMessageCount: Int, limit: Int = 300) {
+        init(_ unreadMessageCount: Int, limit: Int = 999) {
             switch unreadMessageCount {
             case 0:           self = .hidden
             case 1 ... limit: self = .general(unreadMessageCount)


### PR DESCRIPTION
## 작업 내용
close #46
- 읽지 않은 메시지 개수 한도 999개로 수정
- 레이블 크기 수정

## 스크린샷
<img src = "https://github.com/bridge0813/bridge-ios/assets/65343417/35583bc4-0736-4d59-992a-8e963e73b13c" height = 600>

## 리뷰 노트
- 스크린샷만 보시고 코드는 따로 볼필요 없을것 같습니다.
- 얘는 그냥 머지해주셔도 상관 없을것 같아요!
