### PR TITLE
채팅방 목록 화면 바인딩 relay로 변경

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,7 +22,6 @@ opt_in_rules: # 활성화 할 규칙
 - fatal_error_message
 - force_unwrapping
 - implicitly_unwrapped_optional
-- indentation_width
 - literal_expression_end_indentation
 - multiline_arguments
 - multiline_function_chains


### PR DESCRIPTION
## 문제 상황
1. `viewWillAppear`가 여러 번 호출되어 네트워킹이 여러번 발생하는 문제
2. 채팅방 나갈(삭제) 시 기존 채팅방이 업데이트 되지 않아 바뀐 `indexPath`로 접근하면 오류 발생하는 문제
가 있었습니다.

## 효과
1. 네트워킹이 여러번 발생하지 않습니다.
2. 채팅방을 나가도 문제가 발생하지 않습니다.

## 작업 내용
close #45 

## 추가 설명
- 기존 코드를 보면 fetch한 채팅방 observable을 `itemSelected`와 `leaveChatRoomTrigger`에서 `withLatestFrom`으로 구독하고 있었습니다.
- 즉, cold observable에 대한 구독이 다시 이루어져 `viewWillAppear`, `itemSelected`, `leaveChatRoomTrigger` 총 3번의 구독이 발생하였습니다. (`viewWillAppear`가 3번 발생했다기보다는 chatRoom 옵저버블을 3번 구독하는 것이였습니다.)
- 이는 `chatRooms` 옵저버블을 share하면 해결할 수 있습니다.
- 하지만 이 문제와 더불어, 채팅방을 나가면 기존 채팅방 옵저버블을 업데이트 해줘야했기 때문에 옵저버블을 share하는 방식이아닌, 릴레이를 사용해 두 문제를 동시에 해결했습니다.

## 리뷰 노트 
- 매번 채팅방을 나갈때마다 다시 fetch 해오는 방식이 맞는지에 대한 고민이 필요할 것 같습니다.
- 이 부분은 api 나오고나서 다시 생각해볼 예정입니다.
