### PR TITLE
회원가입 플로우 연결

### DIFF
--- a/Bridge.xcodeproj/project.pbxproj
+++ b/Bridge.xcodeproj/project.pbxproj
@@ -7,7 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		7B21C66F2AAFFB2000CEC909 /* EnterNameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B21C66E2AAFFB2000CEC909 /* EnterNameViewModel.swift */; };
+		7B14DB212AB04AE9009A00EB /* SelectFieldViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B14DB202AB04AE9009A00EB /* SelectFieldViewModel.swift */; };
+		7B14DB232AB04B40009A00EB /* SelectFieldViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B14DB222AB04B40009A00EB /* SelectFieldViewController.swift */; };
+		7B14DB252AB04BC5009A00EB /* ASAuthorizationController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B14DB242AB04BC5009A00EB /* ASAuthorizationController+Rx.swift */; };
 		7B2D76E82AA86A2400E5907B /* UIViewController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2D76E72AA86A2400E5907B /* UIViewController+Rx.swift */; };
 		7B2D76EC2AA993C700E5907B /* AuthCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2D76EB2AA993C700E5907B /* AuthCoordinator.swift */; };
 		7B2D76F32AA9941C00E5907B /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2D76F22AA9941C00E5907B /* SignInViewController.swift */; };
@@ -72,7 +74,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		7B21C66E2AAFFB2000CEC909 /* EnterNameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnterNameViewModel.swift; sourceTree = "<group>"; };
+		7B14DB202AB04AE9009A00EB /* SelectFieldViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectFieldViewModel.swift; sourceTree = "<group>"; };
+		7B14DB222AB04B40009A00EB /* SelectFieldViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectFieldViewController.swift; sourceTree = "<group>"; };
+		7B14DB242AB04BC5009A00EB /* ASAuthorizationController+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASAuthorizationController+Rx.swift"; sourceTree = "<group>"; };
 		7B2D76E72AA86A2400E5907B /* UIViewController+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Rx.swift"; sourceTree = "<group>"; };
 		7B2D76EB2AA993C700E5907B /* AuthCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCoordinator.swift; sourceTree = "<group>"; };
 		7B2D76F22AA9941C00E5907B /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
@@ -180,7 +184,8 @@
 		7B2D76FE2AAA16EF00E5907B /* SignUp */ = {
 			isa = PBXGroup;
 			children = (
-				7B21C66E2AAFFB2000CEC909 /* EnterNameViewModel.swift */,
+				7B14DB202AB04AE9009A00EB /* SelectFieldViewModel.swift */,
+				7B14DB222AB04B40009A00EB /* SelectFieldViewController.swift */,
 			);
 			path = SignUp;
 			sourceTree = "<group>";
@@ -411,6 +416,7 @@
 		7BA36CC52A9E148C000DAB02 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				7B14DB242AB04BC5009A00EB /* ASAuthorizationController+Rx.swift */,
 				7B2D76E72AA86A2400E5907B /* UIViewController+Rx.swift */,
 				7BA36CC62A9E14BD000DAB02 /* UITableView+.swift */,
 				7C569D0E2AA0AFD50063D362 /* UICollectionView+.swift */,
@@ -692,6 +698,7 @@
 				7B2D76E82AA86A2400E5907B /* UIViewController+Rx.swift in Sources */,
 				7BB2C23F2A98512400AA2328 /* AppCoordinator.swift in Sources */,
 				7BA36C902A9C4BB3000DAB02 /* ChatRoomListViewModel.swift in Sources */,
+				7B14DB212AB04AE9009A00EB /* SelectFieldViewModel.swift in Sources */,
 				7BA36CD02A9E1888000DAB02 /* BaseTableViewCell.swift in Sources */,
 				7BB2C2472A98549D00AA2328 /* TabBarCoordinator.swift in Sources */,
 				7BB2C2412A9851B600AA2328 /* Coordinator.swift in Sources */,
@@ -699,10 +706,10 @@
 				7BA36C982A9C503C000DAB02 /* FetchChatRoomsUseCase.swift in Sources */,
 				7BA36CB22A9D961F000DAB02 /* ChatRoomDTO.swift in Sources */,
 				7BA36CB92A9D9A29000DAB02 /* HTTP.swift in Sources */,
-				7B21C66F2AAFFB2000CEC909 /* EnterNameViewModel.swift in Sources */,
 				7C569D092A9F7E160063D362 /* DefaultProjectRepository.swift in Sources */,
 				7BA36CC92A9E1640000DAB02 /* Reusable.swift in Sources */,
 				7BA36C9B2A9C5091000DAB02 /* ChatRoom.swift in Sources */,
+				7B14DB232AB04B40009A00EB /* SelectFieldViewController.swift in Sources */,
 				7BA36CCE2A9E185A000DAB02 /* ChatRoomCell.swift in Sources */,
 				7C569D062A9F776B0063D362 /* Date+.swift in Sources */,
 				7B71E7412A9330C6001B5D2C /* AppDelegate.swift in Sources */,
@@ -731,6 +738,7 @@
 				7CF93E052A9C65490013EBD6 /* MainCoordinator.swift in Sources */,
 				7C42701E2AA4540C009BE6AF /* BaseCollectionReusableView.swift in Sources */,
 				7BA36CD32A9F3F6B000DAB02 /* BaseView.swift in Sources */,
+				7B14DB252AB04BC5009A00EB /* ASAuthorizationController+Rx.swift in Sources */,
 				7BA36CBC2A9DA2D1000DAB02 /* NetworkService.swift in Sources */,
 				7C4270142AA3779D009BE6AF /* MainViewModel.swift in Sources */,
 			);

--- a/Bridge/Sources/Presentation/Auth/Coordinator/AuthCoordinator.swift
+++ b/Bridge/Sources/Presentation/Auth/Coordinator/AuthCoordinator.swift
@@ -26,8 +26,21 @@ extension AuthCoordinator {
     func showSignInViewController() {
         let signInViewModel = SignInViewModel(coordinator: self)
         let signInViewController = SignInViewController(viewModel: signInViewModel)
-        navigationController.present(signInViewController, animated: true)
+        
+        let signInNavigationController = UINavigationController(rootViewController: signInViewController)
+        signInNavigationController.setNavigationBarHidden(true, animated: false)
+        signInNavigationController.modalPresentationStyle = .overFullScreen
+        
+        navigationController.present(signInNavigationController, animated: true)
     }
     
-    // 회원가입 플로우 추가
+    // 회원가입 플로우
+    func showSelectFieldViewController() {
+        let selectFieldViewModel = SelectFieldViewModel(coordinator: self)
+        let selectFieldViewController = SelectFieldViewController(viewModel: selectFieldViewModel)
+        
+        if let signInNavController = navigationController.presentedViewController as? UINavigationController {
+            signInNavController.pushViewController(selectFieldViewController, animated: true)
+        }
+    }
 }

--- a/Bridge/Sources/Presentation/Auth/SignIn/SignInViewController.swift
+++ b/Bridge/Sources/Presentation/Auth/SignIn/SignInViewController.swift
@@ -18,7 +18,7 @@ final class SignInViewController: BaseViewController {
     private let rootFlexViewContainer = UIView()
     private let signInWithAppleButton: UIButton = {
         let button = UIButton()
-        button.setTitle("로그인", for: .normal)
+        button.setTitle("애플 로그인", for: .normal)
         button.setTitleColor(.black, for: .normal)
         return button
     }()
@@ -36,6 +36,10 @@ final class SignInViewController: BaseViewController {
     }
     
     // MARK: - Configurations
+    override func configureAttributes() {
+        navigationController?.interactivePopGestureRecognizer?.isEnabled = false
+    }
+    
     override func configureLayouts() {
         view.addSubview(rootFlexViewContainer)
         

--- a/Bridge/Sources/Presentation/Auth/SignIn/SignInViewModel.swift
+++ b/Bridge/Sources/Presentation/Auth/SignIn/SignInViewModel.swift
@@ -29,7 +29,7 @@ final class SignInViewModel: ViewModelType {
     func transform(input: Input) -> Output {
         input.signInWithAppleButtonTapped
             .flatMap {
-                ASAuthorizationAppleIDProvider().rx.signIn()
+                ASAuthorizationAppleIDProvider().rx.requestAuthorizationWithAppleID()
             }
             .withUnretained(self)
             .subscribe(

--- a/Bridge/Sources/Presentation/Auth/SignIn/SignInViewModel.swift
+++ b/Bridge/Sources/Presentation/Auth/SignIn/SignInViewModel.swift
@@ -5,16 +5,17 @@
 //  Created by 정호윤 on 2023/09/08.
 //
 
+import AuthenticationServices
 import RxSwift
 
 final class SignInViewModel: ViewModelType {
     
     struct Input {
-        let signInWithAppleButtonTapped: Observable<Void>?
+        let signInWithAppleButtonTapped: Observable<Void>
     }
     
     struct Output {
-
+        
     }
     
     let disposeBag = DisposeBag()
@@ -26,13 +27,32 @@ final class SignInViewModel: ViewModelType {
     }
     
     func transform(input: Input) -> Output {
-        input.signInWithAppleButtonTapped?
-            .subscribe(onNext: { [weak self] in
-                print("input: sign in with apple button tapped")
-                self?.coordinator?.finish()  // 테스트용
-            })
+        input.signInWithAppleButtonTapped
+            .flatMap {
+                ASAuthorizationAppleIDProvider().rx.signIn()
+            }
+            .withUnretained(self)
+            .subscribe(
+                onNext: { owner, authorization in
+                    owner.coordinator?.showSelectFieldViewController()  // 테스트용
+                },
+                onError: { _ in
+                    // error handling
+                }
+            )
             .disposed(by: disposeBag)
         
         return Output()
     }
+}
+
+extension SignInViewModel {
+//    func foo() {
+//        let userIdentifier = appleIDCredential.user
+//        let userName = appleIDCredential.fullName?.familyName ?? "홍"
+//        let givenName = appleIDCredential.fullName?.givenName ?? "길동"
+//        let fullName = userName + givenName
+//        let authorizationCode = appleIDCredential.authorizationCode
+//        let identityToken = appleIDCredential.identityToken
+//    }
 }

--- a/Bridge/Sources/Presentation/Auth/SignUp/EnterNameViewModel.swift
+++ b/Bridge/Sources/Presentation/Auth/SignUp/EnterNameViewModel.swift
@@ -1,8 +1,0 @@
-//
-//  EnterNameViewModel.swift
-//  Bridge
-//
-//  Created by 정호윤 on 2023/09/12.
-//
-
-import Foundation

--- a/Bridge/Sources/Presentation/Auth/SignUp/SelectFieldViewController.swift
+++ b/Bridge/Sources/Presentation/Auth/SignUp/SelectFieldViewController.swift
@@ -1,0 +1,61 @@
+//
+//  SelectFieldViewController.swift
+//  Bridge
+//
+//  Created by 정호윤 on 2023/09/12.
+//
+
+import UIKit
+import PinLayout
+import FlexLayout
+import RxCocoa
+import RxSwift
+
+final class SelectFieldViewController: BaseViewController {
+    // MARK: - UI
+    private let rootFlexViewContainer = UIView()
+    private let completeButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("완료", for: .normal)
+        button.setTitleColor(.black, for: .normal)
+        return button
+    }()
+    
+    private let viewModel: SelectFieldViewModel
+    
+    init(viewModel: SelectFieldViewModel) {
+        self.viewModel = viewModel
+        super.init()
+    }
+    
+    // MARK: - Lifecycles
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    // MARK: - Configurations
+    override func configureLayouts() {
+        view.addSubview(rootFlexViewContainer)
+        
+        rootFlexViewContainer.flex
+            .direction(.column)
+            .justifyContent(.center)
+            .alignItems(.center)
+            .define { flex in
+                flex.addItem(completeButton).size(100)
+            }
+    }
+    
+    override func viewDidLayoutSubviews() {
+        rootFlexViewContainer.pin.all()
+        rootFlexViewContainer.flex.layout()
+    }
+    
+    override func bind() {
+        let input = SelectFieldViewModel.Input(
+            completeButtonTapped: completeButton.rx.tap.asObservable()
+        )
+        
+        let output = viewModel.transform(input: input)
+    }
+}

--- a/Bridge/Sources/Presentation/Auth/SignUp/SelectFieldViewModel.swift
+++ b/Bridge/Sources/Presentation/Auth/SignUp/SelectFieldViewModel.swift
@@ -1,0 +1,38 @@
+//
+//  SelectFieldViewModel.swift
+//  Bridge
+//
+//  Created by 정호윤 on 2023/09/12.
+//
+
+import RxSwift
+
+final class SelectFieldViewModel: ViewModelType {
+    
+    struct Input {
+        let completeButtonTapped: Observable<Void>
+    }
+    
+    struct Output {
+        
+    }
+    
+    let disposeBag = DisposeBag()
+    
+    weak var coordinator: AuthCoordinator?
+    
+    init(coordinator: AuthCoordinator) {
+        self.coordinator = coordinator
+    }
+    
+    func transform(input: Input) -> Output {
+        input.completeButtonTapped
+            .withUnretained(self)
+            .subscribe(onNext: { owner, authorization in
+                owner.coordinator?.finish()  // 테스트용
+            })
+            .disposed(by: disposeBag)
+        
+        return Output()
+    }
+}

--- a/Bridge/Sources/Presentation/Common/Extensions/ASAuthorizationController+Rx.swift
+++ b/Bridge/Sources/Presentation/Common/Extensions/ASAuthorizationController+Rx.swift
@@ -63,7 +63,7 @@ extension Reactive where Base: ASAuthorizationController {
 }
 
 extension Reactive where Base: ASAuthorizationAppleIDProvider {
-    public func signIn() -> Observable<ASAuthorization> {
+    public func requestAuthorizationWithAppleID() -> Observable<ASAuthorization> {
         let appleIDProvider = base
         let request = appleIDProvider.createRequest()
         request.requestedScopes = [.fullName]

--- a/Bridge/Sources/Presentation/Common/Extensions/ASAuthorizationController+Rx.swift
+++ b/Bridge/Sources/Presentation/Common/Extensions/ASAuthorizationController+Rx.swift
@@ -1,0 +1,75 @@
+//
+//  ASAuthorizationController+Rx.swift
+//  Bridge
+//
+//  Created by 정호윤 on 2023/09/12.
+//
+
+import AuthenticationServices
+import RxCocoa
+import RxSwift
+
+// MARK: - Proxy
+class ASAuthorizationControllerProxy:
+    DelegateProxy<ASAuthorizationController, ASAuthorizationControllerDelegate>,
+    DelegateProxyType {
+    
+    var didComplete = PublishSubject<ASAuthorization>()
+    
+    init(controller: ASAuthorizationController) {
+        super.init(parentObject: controller, delegateProxy: ASAuthorizationControllerProxy.self)
+    }
+    
+    deinit { didComplete.onCompleted() }
+    
+    static func registerKnownImplementations() {
+        register { ASAuthorizationControllerProxy(controller: $0) }
+    }
+    
+    static func currentDelegate(for object: ASAuthorizationController) -> ASAuthorizationControllerDelegate? {
+        object.delegate
+    }
+    
+    static func setCurrentDelegate(_ delegate: ASAuthorizationControllerDelegate?, to object: ASAuthorizationController) {
+        object.delegate = delegate
+    }
+}
+
+// MARK: - Delegate
+extension ASAuthorizationControllerProxy: ASAuthorizationControllerDelegate {
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+        didComplete.onNext(authorization)
+        didComplete.onCompleted()
+    }
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        if (error as NSError).code == ASAuthorizationError.canceled.rawValue {
+            didComplete.onCompleted()
+            return
+        }
+        
+        didComplete.onError(error)
+    }
+}
+
+// MARK: - Reactive
+extension Reactive where Base: ASAuthorizationController {
+    public var didComplete: Observable<ASAuthorization> {
+        ASAuthorizationControllerProxy.proxy(for: base).didComplete.asObservable()
+    }
+}
+
+extension Reactive where Base: ASAuthorizationAppleIDProvider {
+    public func signIn() -> Observable<ASAuthorization> {
+        let appleIDProvider = base
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = [.fullName]
+        
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.performRequests()
+        return authorizationController.rx.didComplete
+    }
+}


### PR DESCRIPTION
## 작업 내용
close #51 
- 로그인 기능을 1차적으로 구현했습니다.
- 회원가입 플로우를 연결했습니다.

## 영상
<img src = "https://github.com/bridge0813/bridge-ios/assets/65343417/1c8a518b-8f06-45ca-8bc8-9f3bd3941bde" height = 600>

## 플로우
- 현재는 로그인하면 회원가입(분야 선택) 화면이 나오는데, 플로우 테스트를 위해 이렇게 했습니다.
- 현재는 분야 선택 화면에서 완료 버튼을 누르면 dismiss 됩니다.
- 나중에는 로그인되면 로그인 뷰를 dismiss할 에정입니다.

## 리뷰 노트
- Rx의 델리게이트 프록시 패턴을 사용했으니 한 번 공부해보시면 좋을것 같습니다.
- 지금 로그인 기능은 애플 서버에 요청해서 데이터를 받아오는 정도만 구현되어있습니다.
- 이제 서버와 연결하는 작업을 진행할듯 싶은데 그 전에 해야할게 좀 많을것으로 예상됩니다...
