### PR TITLE
애플 로그인, 회원가입 구조 구현

### DIFF
--- a/Bridge.xcodeproj/project.pbxproj
+++ b/Bridge.xcodeproj/project.pbxproj
@@ -10,6 +10,13 @@
 		7B14DB212AB04AE9009A00EB /* SelectFieldViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B14DB202AB04AE9009A00EB /* SelectFieldViewModel.swift */; };
 		7B14DB232AB04B40009A00EB /* SelectFieldViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B14DB222AB04B40009A00EB /* SelectFieldViewController.swift */; };
 		7B14DB252AB04BC5009A00EB /* ASAuthorizationController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B14DB242AB04BC5009A00EB /* ASAuthorizationController+Rx.swift */; };
+		7B14DB282AB15E7E009A00EB /* SignInUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B14DB272AB15E7E009A00EB /* SignInUseCase.swift */; };
+		7B14DB2B2AB16272009A00EB /* UserCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B14DB2A2AB16272009A00EB /* UserCredentials.swift */; };
+		7B14DB2E2AB1DA39009A00EB /* SignInResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B14DB2D2AB1DA39009A00EB /* SignInResult.swift */; };
+		7B14DB312AB1DACF009A00EB /* AuthRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B14DB302AB1DACF009A00EB /* AuthRepository.swift */; };
+		7B14DB342AB1DBFD009A00EB /* DefaultAuthRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B14DB332AB1DBFD009A00EB /* DefaultAuthRepository.swift */; };
+		7B14DB362AB2F203009A00EB /* CheckUserAuthStateUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B14DB352AB2F203009A00EB /* CheckUserAuthStateUseCase.swift */; };
+		7B14DB382AB3040F009A00EB /* PlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B14DB372AB3040F009A00EB /* PlaceholderView.swift */; };
 		7B2D76E82AA86A2400E5907B /* UIViewController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2D76E72AA86A2400E5907B /* UIViewController+Rx.swift */; };
 		7B2D76EC2AA993C700E5907B /* AuthCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2D76EB2AA993C700E5907B /* AuthCoordinator.swift */; };
 		7B2D76F32AA9941C00E5907B /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2D76F22AA9941C00E5907B /* SignInViewController.swift */; };
@@ -77,6 +84,13 @@
 		7B14DB202AB04AE9009A00EB /* SelectFieldViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectFieldViewModel.swift; sourceTree = "<group>"; };
 		7B14DB222AB04B40009A00EB /* SelectFieldViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectFieldViewController.swift; sourceTree = "<group>"; };
 		7B14DB242AB04BC5009A00EB /* ASAuthorizationController+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASAuthorizationController+Rx.swift"; sourceTree = "<group>"; };
+		7B14DB272AB15E7E009A00EB /* SignInUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInUseCase.swift; sourceTree = "<group>"; };
+		7B14DB2A2AB16272009A00EB /* UserCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCredentials.swift; sourceTree = "<group>"; };
+		7B14DB2D2AB1DA39009A00EB /* SignInResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInResult.swift; sourceTree = "<group>"; };
+		7B14DB302AB1DACF009A00EB /* AuthRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRepository.swift; sourceTree = "<group>"; };
+		7B14DB332AB1DBFD009A00EB /* DefaultAuthRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAuthRepository.swift; sourceTree = "<group>"; };
+		7B14DB352AB2F203009A00EB /* CheckUserAuthStateUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckUserAuthStateUseCase.swift; sourceTree = "<group>"; };
+		7B14DB372AB3040F009A00EB /* PlaceholderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceholderView.swift; sourceTree = "<group>"; };
 		7B2D76E72AA86A2400E5907B /* UIViewController+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Rx.swift"; sourceTree = "<group>"; };
 		7B2D76EB2AA993C700E5907B /* AuthCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCoordinator.swift; sourceTree = "<group>"; };
 		7B2D76F22AA9941C00E5907B /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
@@ -154,6 +168,47 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		7B14DB262AB15E69009A00EB /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				7B14DB272AB15E7E009A00EB /* SignInUseCase.swift */,
+				7B14DB352AB2F203009A00EB /* CheckUserAuthStateUseCase.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		7B14DB292AB1625D009A00EB /* User */ = {
+			isa = PBXGroup;
+			children = (
+				7B14DB2A2AB16272009A00EB /* UserCredentials.swift */,
+			);
+			path = User;
+			sourceTree = "<group>";
+		};
+		7B14DB2C2AB1D950009A00EB /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				7B14DB2D2AB1DA39009A00EB /* SignInResult.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		7B14DB2F2AB1DAC3009A00EB /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				7B14DB302AB1DACF009A00EB /* AuthRepository.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		7B14DB322AB1DBEC009A00EB /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				7B14DB332AB1DBFD009A00EB /* DefaultAuthRepository.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
 		7B2D76E92AA993AF00E5907B /* Auth */ = {
 			isa = PBXGroup;
 			children = (
@@ -271,6 +326,8 @@
 		7BA36C922A9C4CE5000DAB02 /* Entities */ = {
 			isa = PBXGroup;
 			children = (
+				7B14DB2C2AB1D950009A00EB /* Auth */,
+				7B14DB292AB1625D009A00EB /* User */,
 				7C569CF12A9F67860063D362 /* Main */,
 				7BA36C992A9C5081000DAB02 /* Chat */,
 			);
@@ -280,6 +337,7 @@
 		7BA36C932A9C4CF4000DAB02 /* RepositoryInterfaces */ = {
 			isa = PBXGroup;
 			children = (
+				7B14DB2F2AB1DAC3009A00EB /* Auth */,
 				7C569CFB2A9F6F8A0063D362 /* Main */,
 				7BA36CA52A9C6878000DAB02 /* Chat */,
 			);
@@ -289,6 +347,7 @@
 		7BA36C942A9C4CFF000DAB02 /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
+				7B14DB262AB15E69009A00EB /* Auth */,
 				7C569CF82A9F6D360063D362 /* Main */,
 				7BA36C952A9C4D0F000DAB02 /* Chat */,
 			);
@@ -333,6 +392,7 @@
 		7BA36CA12A9C680A000DAB02 /* Repositories */ = {
 			isa = PBXGroup;
 			children = (
+				7B14DB322AB1DBEC009A00EB /* Auth */,
 				7C569D072A9F7E060063D362 /* Main */,
 				7BA36CA22A9C681B000DAB02 /* Chat */,
 			);
@@ -430,6 +490,7 @@
 			children = (
 				7BA36CD42A9F7D38000DAB02 /* NavigationTitleView.swift */,
 				7C569D122AA1E7020063D362 /* ProjectSectionHeaderView.swift */,
+				7B14DB372AB3040F009A00EB /* PlaceholderView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -694,6 +755,7 @@
 				7BA36C9D2A9C5105000DAB02 /* Message.swift in Sources */,
 				7B2D76F32AA9941C00E5907B /* SignInViewController.swift in Sources */,
 				7BA36CBF2A9DA44F000DAB02 /* NetworkError.swift in Sources */,
+				7B14DB362AB2F203009A00EB /* CheckUserAuthStateUseCase.swift in Sources */,
 				7C569CFA2A9F6D5A0063D362 /* FetchAllProjectsUseCase.swift in Sources */,
 				7B2D76E82AA86A2400E5907B /* UIViewController+Rx.swift in Sources */,
 				7BB2C23F2A98512400AA2328 /* AppCoordinator.swift in Sources */,
@@ -705,9 +767,12 @@
 				7BA36CC72A9E14BD000DAB02 /* UITableView+.swift in Sources */,
 				7BA36C982A9C503C000DAB02 /* FetchChatRoomsUseCase.swift in Sources */,
 				7BA36CB22A9D961F000DAB02 /* ChatRoomDTO.swift in Sources */,
+				7B14DB282AB15E7E009A00EB /* SignInUseCase.swift in Sources */,
 				7BA36CB92A9D9A29000DAB02 /* HTTP.swift in Sources */,
+				7B14DB342AB1DBFD009A00EB /* DefaultAuthRepository.swift in Sources */,
 				7C569D092A9F7E160063D362 /* DefaultProjectRepository.swift in Sources */,
 				7BA36CC92A9E1640000DAB02 /* Reusable.swift in Sources */,
+				7B14DB312AB1DACF009A00EB /* AuthRepository.swift in Sources */,
 				7BA36C9B2A9C5091000DAB02 /* ChatRoom.swift in Sources */,
 				7B14DB232AB04B40009A00EB /* SelectFieldViewController.swift in Sources */,
 				7BA36CCE2A9E185A000DAB02 /* ChatRoomCell.swift in Sources */,
@@ -717,17 +782,20 @@
 				7B71E7432A9330C6001B5D2C /* SceneDelegate.swift in Sources */,
 				7BA36CC12A9DE219000DAB02 /* DefaultNetworkService.swift in Sources */,
 				7C569CFD2A9F6F9E0063D362 /* ProjectRepository.swift in Sources */,
+				7B14DB2B2AB16272009A00EB /* UserCredentials.swift in Sources */,
 				7C569D032A9F72320063D362 /* ProjectDTO.swift in Sources */,
 				7C569D0D2AA0AACC0063D362 /* BaseCollectionViewCell.swift in Sources */,
 				7C569D0F2AA0AFD50063D362 /* UICollectionView+.swift in Sources */,
 				7BB2C24D2A985A4200AA2328 /* ChatCoordinator.swift in Sources */,
 				7BA36CA42A9C6849000DAB02 /* DefaultChatRoomRepository.swift in Sources */,
+				7B14DB2E2AB1DA39009A00EB /* SignInResult.swift in Sources */,
 				7B2D770A2AAB0FDF00E5907B /* SignInViewModel.swift in Sources */,
 				7C4270182AA377E8009BE6AF /* HotProjectCollectionViewCell.swift in Sources */,
 				7C42701C2AA394EF009BE6AF /* UILabel+.swift in Sources */,
 				7BA36CB52A9D9828000DAB02 /* Endpoint.swift in Sources */,
 				7C569D132AA1E7020063D362 /* ProjectSectionHeaderView.swift in Sources */,
 				7BB2C2492A98560E00AA2328 /* TabBarPageType.swift in Sources */,
+				7B14DB382AB3040F009A00EB /* PlaceholderView.swift in Sources */,
 				7BA36CDA2AA197F8000DAB02 /* ChatRoomListViewController.swift in Sources */,
 				7C4270242AA4D434009BE6AF /* FetchHotProjectsUseCase.swift in Sources */,
 				7C569CF32A9F67C60063D362 /* Project.swift in Sources */,

--- a/Bridge/Sources/Data/Network/NetworkService/DefaultNetworkService.swift
+++ b/Bridge/Sources/Data/Network/NetworkService/DefaultNetworkService.swift
@@ -40,5 +40,14 @@ final class DefaultNetworkService: NetworkService {
     func requestTestHotProjectsData() -> Observable<[ProjectDTO]> {
         Observable.just(ProjectDTO.hotProjectTestArray)
     }
-    
+}
+
+// MARK: - For test (auth)
+extension DefaultNetworkService {
+    func signInWithAppleCredentials(_ credentials: UserCredentials) -> Observable<SignInResult> {
+        // 1. user credentials -map-> DTO
+        // 2. request
+        // 3. response handle
+        .just(.needSignUp)
+    }
 }

--- a/Bridge/Sources/Data/Network/NetworkService/NetworkService.swift
+++ b/Bridge/Sources/Data/Network/NetworkService/NetworkService.swift
@@ -17,4 +17,7 @@ protocol NetworkService {
     func requestTestChatRooms() -> Observable<[ChatRoomDTO]>
     
     func leaveChatRoom(id: String) -> Single<Void>
+    
+    // MARK: - For test (auth)
+    func signInWithAppleCredentials(_ credentials: UserCredentials) -> Observable<SignInResult>
 }

--- a/Bridge/Sources/Data/Repositories/Auth/DefaultAuthRepository.swift
+++ b/Bridge/Sources/Data/Repositories/Auth/DefaultAuthRepository.swift
@@ -1,0 +1,22 @@
+//
+//  DefaultAuthRepository.swift
+//  Bridge
+//
+//  Created by 정호윤 on 2023/09/13.
+//
+
+import RxSwift
+
+// TODO: 토큰 매니저? 추가해서 토큰과 user credential 네트워크 서비스로 넘기기
+final class DefaultAuthRepository: AuthRepository {
+    
+    private let networkService: NetworkService
+    
+    init(networkService: NetworkService) {
+        self.networkService = networkService
+    }
+    
+    func signInWithApple(credentials: UserCredentials) -> Observable<SignInResult> {
+        networkService.signInWithAppleCredentials(credentials)
+    }
+}

--- a/Bridge/Sources/Domain/Entities/Auth/SignInResult.swift
+++ b/Bridge/Sources/Domain/Entities/Auth/SignInResult.swift
@@ -1,0 +1,12 @@
+//
+//  SignInResult.swift
+//  Bridge
+//
+//  Created by 정호윤 on 2023/09/13.
+//
+
+enum SignInResult {
+    case signedIn
+    case needSignUp
+    case failure
+}

--- a/Bridge/Sources/Domain/Entities/User/UserCredentials.swift
+++ b/Bridge/Sources/Domain/Entities/User/UserCredentials.swift
@@ -1,0 +1,24 @@
+//
+//  UserCredentials.swift
+//  Bridge
+//
+//  Created by 정호윤 on 2023/09/13.
+//
+
+import Foundation
+
+struct UserCredentials {
+    let id: String
+    let name: String
+    let identityToken: Data?
+    let authorizationCode: Data?
+}
+
+extension UserCredentials {
+    static let onError = UserCredentials(
+        id: "",
+        name: "",
+        identityToken: nil,
+        authorizationCode: nil
+    )
+}

--- a/Bridge/Sources/Domain/RepositoryInterfaces/Auth/AuthRepository.swift
+++ b/Bridge/Sources/Domain/RepositoryInterfaces/Auth/AuthRepository.swift
@@ -1,0 +1,12 @@
+//
+//  AuthRepository.swift
+//  Bridge
+//
+//  Created by 정호윤 on 2023/09/13.
+//
+
+import RxSwift
+
+protocol AuthRepository {
+    func signInWithApple(credentials: UserCredentials) -> Observable<SignInResult>
+}

--- a/Bridge/Sources/Domain/UseCases/Auth/CheckUserAuthStateUseCase.swift
+++ b/Bridge/Sources/Domain/UseCases/Auth/CheckUserAuthStateUseCase.swift
@@ -27,7 +27,7 @@ final class DefaultCheckUserAuthStateUseCase: CheckUserAuthStateUseCase {
     }
 }
 
-// TODO: 로그인 상태 체크 로직
+// TODO: 유저 인증 상태 체크 플로우
 // 1. 로그인 기능이 필요한 기능 (프로젝트 지원하기 등)을 시도 - view model
 // 2. 로그인 상태 체크 (헤더에 토큰 넣어서 서버로 요청 - 토큰 없으면 빈값이 들어가거나 안들어감)
 // 3. 응답 (로그인ok, 회원가입 필요 등)

--- a/Bridge/Sources/Domain/UseCases/Auth/CheckUserAuthStateUseCase.swift
+++ b/Bridge/Sources/Domain/UseCases/Auth/CheckUserAuthStateUseCase.swift
@@ -37,14 +37,10 @@ final class DefaultCheckUserAuthStateUseCase: CheckUserAuthStateUseCase {
 
 private extension DefaultCheckUserAuthStateUseCase {
     private func checkAppleSignInState() -> Observable<UserAuthState> {
-        // Apple 로그인 상태 확인 로직
-        // ...
-        return .just(.signedIn)  // 예시
+        .just(.notSignedIn)  // 예시
     }
     
     private func checkKakaoSignInState() -> Observable<UserAuthState> {
-        // Kakao 로그인 상태 확인 로직
-        // ...
-        return .just(.notSignedIn)  // 예시
+        .just(.notSignedIn)  // 예시
     }
 }

--- a/Bridge/Sources/Domain/UseCases/Auth/CheckUserAuthStateUseCase.swift
+++ b/Bridge/Sources/Domain/UseCases/Auth/CheckUserAuthStateUseCase.swift
@@ -1,0 +1,50 @@
+//
+//  CheckUserAuthStateUseCase.swift
+//  Bridge
+//
+//  Created by 정호윤 on 2023/09/14.
+//
+
+import RxSwift
+
+protocol CheckUserAuthStateUseCase {
+    func execute() -> Observable<UserAuthState>
+}
+
+enum UserAuthState {
+    case signedIn
+    case notSignedIn
+    case error
+}
+
+final class DefaultCheckUserAuthStateUseCase: CheckUserAuthStateUseCase {
+    
+    func execute() -> Observable<UserAuthState> {
+        Observable.combineLatest(checkAppleSignInState(), checkKakaoSignInState())
+            .map { appleSignInState, kakaoSignInState in
+                appleSignInState == .signedIn || kakaoSignInState == .signedIn ? .signedIn : .notSignedIn
+            }
+    }
+}
+
+// TODO: 로그인 상태 체크 로직
+// 1. 로그인 기능이 필요한 기능 (프로젝트 지원하기 등)을 시도 - view model
+// 2. 로그인 상태 체크 (헤더에 토큰 넣어서 서버로 요청 - 토큰 없으면 빈값이 들어가거나 안들어감)
+// 3. 응답 (로그인ok, 회원가입 필요 등)
+// 4. 응답 보고 클라에서 적절한 처리
+//     4-1. 로그인 된 상태 -> 토큰들 키체인에 저장 후 그대로 진행
+//     4-2. 로그인 or 회원가입 필요한 상태 -> 로그인 창 띄우기
+
+private extension DefaultCheckUserAuthStateUseCase {
+    private func checkAppleSignInState() -> Observable<UserAuthState> {
+        // Apple 로그인 상태 확인 로직
+        // ...
+        return .just(.signedIn)  // 예시
+    }
+    
+    private func checkKakaoSignInState() -> Observable<UserAuthState> {
+        // Kakao 로그인 상태 확인 로직
+        // ...
+        return .just(.notSignedIn)  // 예시
+    }
+}

--- a/Bridge/Sources/Domain/UseCases/Auth/SignInUseCase.swift
+++ b/Bridge/Sources/Domain/UseCases/Auth/SignInUseCase.swift
@@ -7,7 +7,7 @@
 
 import RxSwift
 
-// TODO: 로그인 플로우 처리
+// TODO: 로그인 플로우
 // 1. 로그인 창에서 "애플 로그인" 버튼 누르면 - view model
 // 2. 클라단에서 애플 서버에 요청해서 credential 받아와서 - view model
 // 3. 받아온 credential 중 이름, identity token 등 우리 서버에 보내면서 로그인 시도

--- a/Bridge/Sources/Domain/UseCases/Auth/SignInUseCase.swift
+++ b/Bridge/Sources/Domain/UseCases/Auth/SignInUseCase.swift
@@ -1,0 +1,34 @@
+//
+//  SignInUseCase.swift
+//  Bridge
+//
+//  Created by 정호윤 on 2023/09/13.
+//
+
+import RxSwift
+
+// TODO: 로그인 플로우 처리
+// 1. 로그인 창에서 "애플 로그인" 버튼 누르면 - view model
+// 2. 클라단에서 애플 서버에 요청해서 credential 받아와서 - view model
+// 3. 받아온 credential 중 이름, identity token 등 우리 서버에 보내면서 로그인 시도
+// 4. 서버에서 또 응답으로 회원가입인지 or 로그인 성공했는지 + 토큰들 등 응답
+// 5. 응답에 맞는처리
+//     5-1. 로그인: 토큰들 키체인에 저장 -> dismiss
+//     5-2. 신규 유저: 토큰들 키체인에 저장 -> 분야 선택 뷰 push
+
+protocol SignInUseCase {
+    func signInWithApple(credentials: UserCredentials) -> Observable<SignInResult>
+}
+
+final class DefaultSignInUseCase: SignInUseCase {
+    
+    private let authRepository: AuthRepository
+    
+    init(authRepository: AuthRepository) {
+        self.authRepository = authRepository
+    }
+    
+    func signInWithApple(credentials: UserCredentials) -> Observable<SignInResult> {
+        authRepository.signInWithApple(credentials: credentials)
+    }
+}

--- a/Bridge/Sources/Presentation/Auth/Coordinator/AuthCoordinator.swift
+++ b/Bridge/Sources/Presentation/Auth/Coordinator/AuthCoordinator.swift
@@ -13,8 +13,15 @@ final class AuthCoordinator: Coordinator {
     var navigationController: UINavigationController
     var childCoordinators: [Coordinator] = []
     
+    private let authRepository: AuthRepository
+    private let signInUseCase: SignInUseCase
+    
     init(navigationController: UINavigationController) {
         self.navigationController = navigationController
+        
+        let networkService = DefaultNetworkService()
+        authRepository = DefaultAuthRepository(networkService: networkService)
+        signInUseCase = DefaultSignInUseCase(authRepository: authRepository)
     }
     
     func start() {
@@ -24,12 +31,14 @@ final class AuthCoordinator: Coordinator {
 
 extension AuthCoordinator {
     func showSignInViewController() {
-        let signInViewModel = SignInViewModel(coordinator: self)
+        let signInViewModel = SignInViewModel(coordinator: self, signInUseCase: signInUseCase)
         let signInViewController = SignInViewController(viewModel: signInViewModel)
         
         let signInNavigationController = UINavigationController(rootViewController: signInViewController)
         signInNavigationController.setNavigationBarHidden(true, animated: false)
-        signInNavigationController.modalPresentationStyle = .overFullScreen
+        
+        // TODO: 로그인 화면에 x 버튼 추가하지 전까지 주석처리
+//        signInNavigationController.modalPresentationStyle = .overFullScreen
         
         navigationController.present(signInNavigationController, animated: true)
     }

--- a/Bridge/Sources/Presentation/Common/Extensions/ASAuthorizationController+Rx.swift
+++ b/Bridge/Sources/Presentation/Common/Extensions/ASAuthorizationController+Rx.swift
@@ -40,7 +40,7 @@ extension ASAuthorizationControllerProxy: ASAuthorizationControllerDelegate {
     func authorizationController(
         controller: ASAuthorizationController,
         didCompleteWithAuthorization authorization: ASAuthorization
-    ) {
+    ) { 
         didComplete.onNext(authorization)
         didComplete.onCompleted()
     }

--- a/Bridge/Sources/Presentation/Common/Views/PlaceholderView.swift
+++ b/Bridge/Sources/Presentation/Common/Views/PlaceholderView.swift
@@ -1,0 +1,47 @@
+//
+//  PlaceholderView.swift
+//  Bridge
+//
+//  Created by 정호윤 on 2023/09/14.
+//
+
+import UIKit
+import FlexLayout
+import PinLayout
+
+final class PlaceholderView: BaseView {
+    
+    private let rootFlexContainer = UIView()
+    
+    private let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16)
+        label.textAlignment = .center
+        return label
+    }()
+    
+    init(description: String? = nil) {
+        descriptionLabel.text = description
+        super.init(frame: .zero)
+    }
+    
+    override func configureLayouts() {
+        addSubview(rootFlexContainer)
+        
+        rootFlexContainer.flex.direction(.column).justifyContent(.center).alignItems(.center).define { flex in
+            flex.addItem(descriptionLabel).margin(10)
+        }
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        rootFlexContainer.pin.all()
+        rootFlexContainer.flex.layout()
+    }
+}
+
+extension PlaceholderView {
+    func configurePlaceholderView(description: String?) {
+        descriptionLabel.text = description
+    }
+}

--- a/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomCell.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomCell.swift
@@ -12,6 +12,7 @@ import PinLayout
 final class ChatRoomCell: BaseTableViewCell {
     
     // MARK: - UI
+    // rootFlexContainer
     private let chatRoomBackgroundView: UIView = {
         let view = UIView()
         view.backgroundColor = .systemGray5
@@ -133,9 +134,9 @@ private extension ChatRoomCell {
         
         init(_ unreadMessageCount: Int, limit: Int = 999) {
             switch unreadMessageCount {
-            case 0:           self = .hidden
-            case 1 ... limit: self = .general(unreadMessageCount)
-            default:          self = .exceededLimit(limit)
+            case 0:             self = .hidden
+            case 1 ... limit:   self = .general(unreadMessageCount)
+            default:            self = .exceededLimit(limit)
             }
         }
         
@@ -149,8 +150,8 @@ private extension ChatRoomCell {
         
         var shouldIncludeInLayout: Bool {
             switch self {
-            case .hidden:                  return false
-            case .general, .exceededLimit: return true
+            case .hidden:                   return false
+            case .general, .exceededLimit:  return true
             }
         }
         

--- a/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewModel.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewModel.swift
@@ -19,6 +19,7 @@ final class ChatRoomListViewModel: ViewModelType {
     
     struct Output {
         let chatRooms: Driver<[ChatRoom]>
+        let viewState: Driver<ViewState>
     }
     
     let disposeBag = DisposeBag()
@@ -26,25 +27,36 @@ final class ChatRoomListViewModel: ViewModelType {
     private weak var coordinator: ChatCoordinator?
     private let fetchChatRoomsUseCase: FetchChatRoomsUseCase
     private let leaveChatRoomUseCase: LeaveChatRoomUseCase
+    private let checkUserAuthStateUseCase: CheckUserAuthStateUseCase
     
     init(
         coordinator: ChatCoordinator,
         fetchChatRoomsUseCase: FetchChatRoomsUseCase,
-        leaveChatRoomUseCase: LeaveChatRoomUseCase
+        leaveChatRoomUseCase: LeaveChatRoomUseCase,
+        checkUserAuthStateUseCase: CheckUserAuthStateUseCase
     ) {
         self.coordinator = coordinator
         self.fetchChatRoomsUseCase = fetchChatRoomsUseCase
         self.leaveChatRoomUseCase = leaveChatRoomUseCase
+        self.checkUserAuthStateUseCase = checkUserAuthStateUseCase
     }
     
     // TODO: apns 들어오면 구조 바꿔야할수도
     func transform(input: Input) -> Output {
         let chatRooms = BehaviorRelay<[ChatRoom]>(value: [])
+        let viewState = BehaviorRelay<ViewState>(value: .general)
         
-        input.viewWillAppear
+        let userAuthState = input.viewWillAppear
             .withUnretained(self)
             .flatMapLatest { owner, _ in
-                owner.fetchChatRooms()
+                owner.checkUserAuthStateUseCase.execute()
+            }
+            .distinctUntilChanged()
+        
+        userAuthState
+            .withUnretained(self)
+            .flatMapLatest { owner, userAuthState in
+                owner.fetchChatRoomsBasedOn(userAuthState: userAuthState)
             }
             .bind(to: chatRooms)
             .disposed(by: disposeBag)
@@ -75,19 +87,54 @@ final class ChatRoomListViewModel: ViewModelType {
             .bind(to: chatRooms)
             .disposed(by: disposeBag)
         
-        return Output(chatRooms: chatRooms.asDriver(onErrorJustReturn: [ChatRoom.onError]))
+        // 뷰 상태 결정
+        Observable.combineLatest(userAuthState, chatRooms)
+            .map { [weak self] userAuthState, chatRooms in
+                self?.configureViewState(userAuthState: userAuthState, chatRooms: chatRooms) ?? .error
+            }
+            .bind(to: viewState)
+            .disposed(by: disposeBag)
+        
+        return Output(
+            chatRooms: chatRooms.asDriver(),
+            viewState: viewState.asDriver(onErrorJustReturn: .error)
+        )
     }
 }
 
-extension ChatRoomListViewModel {
-    private func fetchChatRooms() -> Observable<[ChatRoom]> {
-        return fetchChatRoomsUseCase.execute()
+private extension ChatRoomListViewModel {
+    func fetchChatRoomsBasedOn(userAuthState: UserAuthState) -> Observable<[ChatRoom]> {
+        switch userAuthState {
+        case .signedIn: return fetchChatRooms()
+        default:        return .just([])
+        }
     }
+    
+    func fetchChatRooms() -> Observable<[ChatRoom]> {
+        fetchChatRoomsUseCase.execute()
+    }
+    
+    func configureViewState(userAuthState: UserAuthState, chatRooms: [ChatRoom]) -> ViewState {
+        switch userAuthState {
+        case .signedIn:     return chatRooms.isEmpty ? .empty : .general
+        case .notSignedIn:  return .notSignedIn
+        case .error:        return .error
+        }
+    }
+
 }
 
 // MARK: Data source
 extension ChatRoomListViewModel {
     enum Section: CaseIterable {
         case main
+    }
+    
+    /// ChatRoomListTableView에서 보여줘야 하는 화면을 결정
+    enum ViewState {
+        case general
+        case empty
+        case notSignedIn
+        case error
     }
 }

--- a/Bridge/Sources/Presentation/Tab/Chat/Coordinator/ChatCoordinator.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/Coordinator/ChatCoordinator.swift
@@ -16,6 +16,7 @@ final class ChatCoordinator: Coordinator {
     private let chatRoomRepository: ChatRoomRepository
     private let fetchChatRoomsUseCase: FetchChatRoomsUseCase
     private let leaveChatRoomUseCase: LeaveChatRoomUseCase
+    private let checkUserAuthStateUseCase: CheckUserAuthStateUseCase
     
     init(navigationController: UINavigationController) {
         self.navigationController = navigationController
@@ -25,6 +26,7 @@ final class ChatCoordinator: Coordinator {
         chatRoomRepository = DefaultChatRoomRepository(networkService: networkService)
         fetchChatRoomsUseCase = DefaultFetchChatRoomsUseCase(chatRoomRepository: chatRoomRepository)
         leaveChatRoomUseCase = DefaultLeaveChatRoomUseCase(chatRoomRepository: chatRoomRepository)
+        checkUserAuthStateUseCase = DefaultCheckUserAuthStateUseCase()
     }
     
     func start() {
@@ -37,7 +39,8 @@ extension ChatCoordinator {
         let chatRoomListViewModel = ChatRoomListViewModel(
             coordinator: self,
             fetchChatRoomsUseCase: fetchChatRoomsUseCase,
-            leaveChatRoomUseCase: leaveChatRoomUseCase
+            leaveChatRoomUseCase: leaveChatRoomUseCase,
+            checkUserAuthStateUseCase: checkUserAuthStateUseCase
         )
         let viewController = ChatRoomListViewController(viewModel: chatRoomListViewModel)
         navigationController.pushViewController(viewController, animated: true)


### PR DESCRIPTION
## 작업 내용
close #54 
- 유저의 인증 상태(로그인 or 비로그인)를 어떤 방식으로 체크할지에 대한 구조를 설계했습니다.
- 유저의 로그인 및 회원가입을 어떤 방식으로 처리할지에 대한 구조를 설계했습니다.

## 스크린샷
- 뷰 상태별로 다른 화면을 보여주는 예시입니다.
- 아래의 경우 로그인 안된 상태의 채팅방 목록 화면입니다.
<img src = "https://github.com/bridge0813/bridge-ios/assets/65343417/f3e844c6-a804-419f-a052-e8e9777add8c" height = 600>

## 플로우
### 유저 인증 상태 체크 플로우
1. 로그인 기능이 필요한 기능(프로젝트 지원하기 등) 사용 시도
2. 로그인 상태 체크 (헤더에 토큰 넣어서 서버로 요청 - 토큰이 없으면 빈 값이 들어가거나 안들어가겠죠?)
3. 서버 응답 (로그인 된 상태, 회원가입이 필요한 상태 등)
4. 응답에 맞는 처리
     4-1. 로그인 된 상태 -> 토큰들 키체인에 저장 후 기능 사용
     4-2. 로그인 or 회원가입 필요한 상태 -> 로그인 화면 띄우기

### 로그인 및 회원가입 플로우
1. 로그인 화면에서 "애플 로그인" 버튼 터치
2. (클라) 애플 서버에 요청해 credential 받아옴
3. 받아온 credential 중 이름이나 identity token 등 우리 서버에 보내면서 로그인 시도
4. 서버 응답(신규 유저 or 로그인 성공했는지 + 토큰들)
5. 응답에 맞는 처리
    5-1. 로그인: 토큰들 키체인에 저장 -> 로그인 화면 dismiss
    5-2. 신규 유저: 토큰들 키체인에 저장 -> (회원 가입이므로) 분야 선택 화면 push

## 리뷰 노트
- 유저 인증 상태를 체크하는 구조는 유스케이스까지만 만든 상태입니다. 나머지는 곧 구현할 예정입니다.
- 서버 응답으로 오는 토큰을 저장하는 키체인 저장소를 구현할 예정입니다.
- 리뷰는 애플 로그인 관련 코드보다는 구조가 클린 아키텍처에 부합하는지를 중점적으로 봐주시면 될 것 같습니다.

## 레퍼런스
- 애플 로그인 자체를 아실필요는 없지만, 애플 로그인과 관련된 개념은 알아두시면 좋을것 같아 링크 달아두겠습니다!
- [관련 개념](https://weekoding.tistory.com/27?category=1249493)
