### PR TITLE
채팅방 목록 플레이스홀더 오류 수정 및 리팩토링

### DIFF
--- a/Bridge/Sources/Domain/UseCases/Auth/CheckUserAuthStateUseCase.swift
+++ b/Bridge/Sources/Domain/UseCases/Auth/CheckUserAuthStateUseCase.swift
@@ -37,7 +37,7 @@ final class DefaultCheckUserAuthStateUseCase: CheckUserAuthStateUseCase {
 
 private extension DefaultCheckUserAuthStateUseCase {
     private func checkAppleSignInState() -> Observable<UserAuthState> {
-        .just(.notSignedIn)  // 예시
+        .just(.signedIn)  // 예시
     }
     
     private func checkKakaoSignInState() -> Observable<UserAuthState> {

--- a/Bridge/Sources/Presentation/Common/Views/PlaceholderView.swift
+++ b/Bridge/Sources/Presentation/Common/Views/PlaceholderView.swift
@@ -6,8 +6,6 @@
 //
 
 import UIKit
-import FlexLayout
-import PinLayout
 
 final class PlaceholderView: BaseView {
     
@@ -26,17 +24,14 @@ final class PlaceholderView: BaseView {
     }
     
     override func configureLayouts() {
-        addSubview(rootFlexContainer)
+        addSubview(descriptionLabel)
         
-        rootFlexContainer.flex.direction(.column).justifyContent(.center).alignItems(.center).define { flex in
-            flex.addItem(descriptionLabel).margin(10)
-        }
-    }
-    
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        rootFlexContainer.pin.all()
-        rootFlexContainer.flex.layout()
+        descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            descriptionLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            descriptionLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
     }
 }
 

--- a/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewController.swift
@@ -155,7 +155,7 @@ private extension ChatRoomListViewController {
             placeholderView.configurePlaceholderView(description: "로그인 후 이용할 수 있어요.")
             
         case .empty:
-            placeholderView.configurePlaceholderView(description: "프로젝트를 지원하고 채팅을 시작해보세요!")
+            placeholderView.configurePlaceholderView(description: "프로젝트에 지원하고 채팅을 시작해보세요!")
             
         case .error:
             placeholderView.configurePlaceholderView(description: "알 수 없는 오류가 발생했습니다.")

--- a/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewController.swift
@@ -80,7 +80,7 @@ final class ChatRoomListViewController: BaseViewController {
         
         let input = ChatRoomListViewModel.Input(
             viewWillAppear: self.rx.viewWillAppear.asObservable(),
-            itemSelected: chatRoomListTableView.rx.itemSelected.map { $0.row }.asObservable(),
+            itemSelected: chatRoomListTableView.rx.itemSelected.map { $0.row },
             leaveChatRoomTrigger: leaveChatRoomTrigger.asObservable()
         )
         let output = viewModel.transform(input: input)

--- a/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewController.swift
@@ -29,7 +29,7 @@ final class ChatRoomListViewController: BaseViewController {
     private var dataSource: DataSource?
     
     private let viewModel: ChatRoomListViewModel
-    private let leaveChatRoomTrigger = PublishRelay<IndexPath>()
+    private let leaveChatRoomTrigger = PublishRelay<Int>()
     
     init(viewModel: ChatRoomListViewModel) {
         self.viewModel = viewModel
@@ -80,8 +80,8 @@ final class ChatRoomListViewController: BaseViewController {
         
         let input = ChatRoomListViewModel.Input(
             viewWillAppear: self.rx.viewWillAppear.asObservable(),
-            itemSelected: chatRoomListTableView.rx.itemSelected.asObservable(),
-            leaveChatRoomTrigger: leaveChatRoomTrigger
+            itemSelected: chatRoomListTableView.rx.itemSelected.map { $0.row }.asObservable(),
+            leaveChatRoomTrigger: leaveChatRoomTrigger.asObservable()
         )
         let output = viewModel.transform(input: input)
         
@@ -96,6 +96,7 @@ final class ChatRoomListViewController: BaseViewController {
         
         output.viewState
             .drive { [weak self] viewState in
+                print(viewState)
                 self?.handleViewState(viewState)
             }
             .disposed(by: disposeBag)
@@ -130,7 +131,7 @@ extension ChatRoomListViewController: UITableViewDelegate {
         trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
     ) -> UISwipeActionsConfiguration? {
         let deleteAction = UIContextualAction(style: .destructive, title: "나가기") { [weak self] _, _, completion in
-            self?.leaveChatRoomTrigger.accept(indexPath)
+            self?.leaveChatRoomTrigger.accept(indexPath.row)
             completion(true)
         }
         

--- a/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewModel.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewModel.swift
@@ -5,7 +5,6 @@
 //  Created by 정호윤 on 2023/08/28.
 //
 
-import Foundation
 import RxCocoa
 import RxSwift
 
@@ -13,8 +12,8 @@ final class ChatRoomListViewModel: ViewModelType {
     
     struct Input {
         let viewWillAppear: Observable<Bool>
-        let itemSelected: Observable<IndexPath>
-        let leaveChatRoomTrigger: PublishRelay<IndexPath>
+        let itemSelected: Observable<Int>
+        let leaveChatRoomTrigger: Observable<Int>
     }
     
     struct Output {
@@ -62,8 +61,8 @@ final class ChatRoomListViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         input.itemSelected
-            .withLatestFrom(chatRooms) { indexPath, chatRooms in
-                chatRooms[indexPath.row]
+            .withLatestFrom(chatRooms) { index, chatRooms in
+                chatRooms[index]
             }
             .withUnretained(self)
             .subscribe(onNext: { owner, chatRoom in
@@ -73,8 +72,8 @@ final class ChatRoomListViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         input.leaveChatRoomTrigger
-            .withLatestFrom(chatRooms) { indexPath, chatRooms in
-                chatRooms[indexPath.row]
+            .withLatestFrom(chatRooms) { index, chatRooms in
+                chatRooms[index]
             }
             .withUnretained(self)
             .flatMap { owner, chatRoom in


### PR DESCRIPTION
## 배경
- 채팅방을 전부 삭제해도 플레이스홀더 뷰가 나오지 않는 문제가 있었습니다.
- 뷰 컨트롤러에서 input으로 넘겨주는 값의 타입이 `IndexPath` 였습니다.

## 작업 내용
close #58
- flexlayout과 관련된 문제였기에, autolayout을 사용해 해결했습니다.
- IndexPath가 아닌 Int를 input으로 전달하도록 변경하여 `Foundation`에 대한 의존성을 제거했습니다.

## 영상
<img src = "https://github.com/bridge0813/bridge-ios/assets/65343417/1baf3839-04a5-4071-a835-f51056f35bc5" height = 600>

## 리뷰 노트
- flexlayout으로 레이아웃을 잡을때 외부에서(e.g. 뷰컨) 뷰의 값을 수정하면 뭔가 레이아웃에서 빠지는 느낌인데...
- 왜 그런지 모르겠네요 ㅠㅠ` flex.layout()` 실행해도 잘 안돼서 그냥 오토레이아웃으로 했습니다...
