### PR TITLE
디자인 시스템(Component)의 Tooltip, Message box 구현

### DIFF
--- a/Bridge.xcodeproj/project.pbxproj
+++ b/Bridge.xcodeproj/project.pbxproj
@@ -40,7 +40,9 @@
 		7B6123822AC15D2E006E72C1 /* Pretendard-Thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = 7B6123792AC15D2E006E72C1 /* Pretendard-Thin.otf */; };
 		7B6123842AC1A65F006E72C1 /* BridgeColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6123832AC1A65F006E72C1 /* BridgeColor.swift */; };
 		7B6123862AC1B199006E72C1 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6123852AC1B199006E72C1 /* UIImage+.swift */; };
-		7B61238B2AC2D03E006E72C1 /* MessageBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B61238A2AC2D03E006E72C1 /* MessageBoxView.swift */; };
+		7B61238B2AC2D03E006E72C1 /* TipMessageBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B61238A2AC2D03E006E72C1 /* TipMessageBox.swift */; };
+		7B61238D2AC2F320006E72C1 /* WarningMessageBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B61238C2AC2F320006E72C1 /* WarningMessageBox.swift */; };
+		7B61238F2AC2FBD8006E72C1 /* MessageBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B61238E2AC2FBD8006E72C1 /* MessageBox.swift */; };
 		7B71E7412A9330C6001B5D2C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B71E7402A9330C6001B5D2C /* AppDelegate.swift */; };
 		7B71E7432A9330C6001B5D2C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B71E7422A9330C6001B5D2C /* SceneDelegate.swift */; };
 		7B71E74A2A9330C7001B5D2C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7B71E7492A9330C7001B5D2C /* Assets.xcassets */; };
@@ -160,7 +162,9 @@
 		7B6123792AC15D2E006E72C1 /* Pretendard-Thin.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Thin.otf"; sourceTree = "<group>"; };
 		7B6123832AC1A65F006E72C1 /* BridgeColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeColor.swift; sourceTree = "<group>"; };
 		7B6123852AC1B199006E72C1 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
-		7B61238A2AC2D03E006E72C1 /* MessageBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBoxView.swift; sourceTree = "<group>"; };
+		7B61238A2AC2D03E006E72C1 /* TipMessageBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipMessageBox.swift; sourceTree = "<group>"; };
+		7B61238C2AC2F320006E72C1 /* WarningMessageBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarningMessageBox.swift; sourceTree = "<group>"; };
+		7B61238E2AC2FBD8006E72C1 /* MessageBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBox.swift; sourceTree = "<group>"; };
 		7B71E73D2A9330C6001B5D2C /* Bridge.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bridge.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B71E7402A9330C6001B5D2C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7B71E7422A9330C6001B5D2C /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -409,7 +413,9 @@
 		7B6123872AC2D00C006E72C1 /* MessageBox */ = {
 			isa = PBXGroup;
 			children = (
-				7B61238A2AC2D03E006E72C1 /* MessageBoxView.swift */,
+				7B61238A2AC2D03E006E72C1 /* TipMessageBox.swift */,
+				7B61238C2AC2F320006E72C1 /* WarningMessageBox.swift */,
+				7B61238E2AC2FBD8006E72C1 /* MessageBox.swift */,
 			);
 			path = MessageBox;
 			sourceTree = "<group>";
@@ -1093,7 +1099,7 @@
 				7CC9F6C52AAEEAF300685EA9 /* MemberFieldSelectionViewModel.swift in Sources */,
 				7C569D0F2AA0AFD50063D362 /* UICollectionView+.swift in Sources */,
 				7B6123862AC1B199006E72C1 /* UIImage+.swift in Sources */,
-				7B61238B2AC2D03E006E72C1 /* MessageBoxView.swift in Sources */,
+				7B61238B2AC2D03E006E72C1 /* TipMessageBox.swift in Sources */,
 				7C24003B2AB2C86100D9D5F1 /* ApplicantRestrictionViewController.swift in Sources */,
 				7BB2C24D2A985A4200AA2328 /* ChatCoordinator.swift in Sources */,
 				7B61235E2ABD9CBC006E72C1 /* SignInWithAppleRequestDTO.swift in Sources */,
@@ -1122,9 +1128,11 @@
 				7BA36C8E2A9C4B33000DAB02 /* ViewModelType.swift in Sources */,
 				7C24003D2AB34BFA00D9D5F1 /* FieldTagButton.swift in Sources */,
 				7CF93E052A9C65490013EBD6 /* MainCoordinator.swift in Sources */,
+				7B61238D2AC2F320006E72C1 /* WarningMessageBox.swift in Sources */,
 				7C42701E2AA4540C009BE6AF /* BaseCollectionReusableView.swift in Sources */,
 				7B14DB522AB86982009A00EB /* KeychainAccount.swift in Sources */,
 				7BA36CD32A9F3F6B000DAB02 /* BaseView.swift in Sources */,
+				7B61238F2AC2FBD8006E72C1 /* MessageBox.swift in Sources */,
 				7B14DB252AB04BC5009A00EB /* ASAuthorizationController+Rx.swift in Sources */,
 				7C24002C2AB1B88C00D9D5F1 /* ProjectOverviewInputViewController.swift in Sources */,
 				7BA36CBC2A9DA2D1000DAB02 /* NetworkService.swift in Sources */,

--- a/Bridge.xcodeproj/project.pbxproj
+++ b/Bridge.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		7B6123822AC15D2E006E72C1 /* Pretendard-Thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = 7B6123792AC15D2E006E72C1 /* Pretendard-Thin.otf */; };
 		7B6123842AC1A65F006E72C1 /* BridgeColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6123832AC1A65F006E72C1 /* BridgeColor.swift */; };
 		7B6123862AC1B199006E72C1 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6123852AC1B199006E72C1 /* UIImage+.swift */; };
+		7B61238B2AC2D03E006E72C1 /* MessageBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B61238A2AC2D03E006E72C1 /* MessageBoxView.swift */; };
 		7B71E7412A9330C6001B5D2C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B71E7402A9330C6001B5D2C /* AppDelegate.swift */; };
 		7B71E7432A9330C6001B5D2C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B71E7422A9330C6001B5D2C /* SceneDelegate.swift */; };
 		7B71E74A2A9330C7001B5D2C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7B71E7492A9330C7001B5D2C /* Assets.xcassets */; };
@@ -159,6 +160,7 @@
 		7B6123792AC15D2E006E72C1 /* Pretendard-Thin.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Thin.otf"; sourceTree = "<group>"; };
 		7B6123832AC1A65F006E72C1 /* BridgeColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeColor.swift; sourceTree = "<group>"; };
 		7B6123852AC1B199006E72C1 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
+		7B61238A2AC2D03E006E72C1 /* MessageBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBoxView.swift; sourceTree = "<group>"; };
 		7B71E73D2A9330C6001B5D2C /* Bridge.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bridge.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B71E7402A9330C6001B5D2C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7B71E7422A9330C6001B5D2C /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -402,6 +404,14 @@
 				7B6123792AC15D2E006E72C1 /* Pretendard-Thin.otf */,
 			);
 			path = Font;
+			sourceTree = "<group>";
+		};
+		7B6123872AC2D00C006E72C1 /* MessageBox */ = {
+			isa = PBXGroup;
+			children = (
+				7B61238A2AC2D03E006E72C1 /* MessageBoxView.swift */,
+			);
+			path = MessageBox;
 			sourceTree = "<group>";
 		};
 		7B71E7342A9330C6001B5D2C = {
@@ -725,6 +735,7 @@
 			isa = PBXGroup;
 			children = (
 				7C1366402AC2783100EB415D /* Buttons */,
+				7B6123872AC2D00C006E72C1 /* MessageBox */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -1082,6 +1093,7 @@
 				7CC9F6C52AAEEAF300685EA9 /* MemberFieldSelectionViewModel.swift in Sources */,
 				7C569D0F2AA0AFD50063D362 /* UICollectionView+.swift in Sources */,
 				7B6123862AC1B199006E72C1 /* UIImage+.swift in Sources */,
+				7B61238B2AC2D03E006E72C1 /* MessageBoxView.swift in Sources */,
 				7C24003B2AB2C86100D9D5F1 /* ApplicantRestrictionViewController.swift in Sources */,
 				7BB2C24D2A985A4200AA2328 /* ChatCoordinator.swift in Sources */,
 				7B61235E2ABD9CBC006E72C1 /* SignInWithAppleRequestDTO.swift in Sources */,

--- a/Bridge/Sources/Presentation/Auth/SignIn/SignInViewController.swift
+++ b/Bridge/Sources/Presentation/Auth/SignIn/SignInViewController.swift
@@ -56,6 +56,7 @@ final class SignInViewController: BaseViewController {
     }
     
     override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         rootFlexViewContainer.pin.all()
         rootFlexViewContainer.flex.layout()
     }

--- a/Bridge/Sources/Presentation/Auth/SignUp/SelectFieldViewController.swift
+++ b/Bridge/Sources/Presentation/Auth/SignUp/SelectFieldViewController.swift
@@ -15,13 +15,8 @@ final class SelectFieldViewController: BaseViewController {
     // MARK: - UI
     private let rootFlexViewContainer = UIView()
     
-    private let label: UILabel = {
-        let label = UILabel()
-        label.text = "테스트용 레이블"
-        label.font = BridgeFont.headline1.font
-        label.textColor = BridgeFont.headline1.textColor
-        return label
-    }()
+    private let tipMessageBox = TipMessageBox("관심 분야 설정하고 맞춤 홈화면 확인하세요!")
+    private let warningMessageBox = WarningMessageBox("이 프로젝트는 학생, 취준생의 지원이 제한되어 있습니다.")
     
     private let completeButton: UIButton = {
         let button = UIButton(configuration: .filled())
@@ -48,12 +43,16 @@ final class SelectFieldViewController: BaseViewController {
         view.addSubview(rootFlexViewContainer)
         
         rootFlexViewContainer.flex.direction(.column).justifyContent(.center).alignItems(.center).define { flex in
-            flex.addItem(label)
+            flex.addItem(tipMessageBox)
+            flex.addItem().size(40)
+            flex.addItem(warningMessageBox)
+            flex.addItem().size(40)
             flex.addItem(completeButton).width(343).height(52)
         }
     }
     
     override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         rootFlexViewContainer.pin.all()
         rootFlexViewContainer.flex.layout()
     }

--- a/Bridge/Sources/Presentation/Common/Bases/BaseView.swift
+++ b/Bridge/Sources/Presentation/Common/Bases/BaseView.swift
@@ -35,4 +35,8 @@ class BaseView: UIView {
     
     /// 뷰 모델과 뷰를 바인딩하기 위한 메서드
     func bind() { }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+    }
 }

--- a/Bridge/Sources/Presentation/DesignSystem/Component/MessageBox/MessageBox.swift
+++ b/Bridge/Sources/Presentation/DesignSystem/Component/MessageBox/MessageBox.swift
@@ -1,0 +1,47 @@
+//
+//  MessageBox.swift
+//  Bridge
+//
+//  Created by 정호윤 on 2023/09/26.
+//
+
+import UIKit
+import FlexLayout
+import PinLayout
+
+class MessageBox: BaseView {
+    // MARK: - UI
+    let backgroundView: UIView = {
+        let view = UIView()
+        view.backgroundColor = BridgeColor.secondary4
+        view.layer.cornerRadius = 4
+        return view
+    }()
+    
+    let messageLabel: UILabel = {
+        let label = UILabel()
+        label.font = BridgeFont.caption1.font
+        label.textColor = BridgeColor.gray2
+        label.textAlignment = .left
+        return label
+    }()
+    
+    // MARK: - Layout
+    override func configureLayouts() {
+        addSubview(backgroundView)
+        
+        backgroundView.flex
+            .direction(.row)
+            .justifyContent(.start)
+            .alignItems(.center)
+            .width(343)
+            .height(38)
+            .padding(13)
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        backgroundView.pin.all()
+        backgroundView.flex.layout()
+    }
+}

--- a/Bridge/Sources/Presentation/DesignSystem/Component/MessageBox/TipMessageBox.swift
+++ b/Bridge/Sources/Presentation/DesignSystem/Component/MessageBox/TipMessageBox.swift
@@ -30,7 +30,7 @@ final class TipMessageBox: MessageBox {
         
         backgroundView.flex.define { flex in
             flex.addItem(tipLabel).marginRight(12)
-            flex.addItem(messageLabel)
+            flex.addItem(messageLabel).marginRight(13)
         }
     }
     

--- a/Bridge/Sources/Presentation/DesignSystem/Component/MessageBox/TipMessageBox.swift
+++ b/Bridge/Sources/Presentation/DesignSystem/Component/MessageBox/TipMessageBox.swift
@@ -1,0 +1,40 @@
+//
+//  TipMessageBox.swift
+//  Bridge
+//
+//  Created by 정호윤 on 2023/09/26.
+//
+
+import UIKit
+import PinLayout
+import FlexLayout
+
+final class TipMessageBox: MessageBox {
+    
+    private let tipLabel: UILabel = {
+        let label = UILabel()
+        label.text = "TIP"
+        label.font = BridgeFont.body3.font
+        label.textColor = BridgeColor.secondary1
+        return label
+    }()
+    
+    init(_ message: String) {
+        super.init(frame: .zero)
+        messageLabel.text = message
+    }
+    
+    // MARK: - Layouts
+    override func configureLayouts() {
+        super.configureLayouts()
+        
+        backgroundView.flex.define { flex in
+            flex.addItem(tipLabel).marginRight(12)
+            flex.addItem(messageLabel)
+        }
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+    }
+}

--- a/Bridge/Sources/Presentation/DesignSystem/Component/MessageBox/WarningMessageBox.swift
+++ b/Bridge/Sources/Presentation/DesignSystem/Component/MessageBox/WarningMessageBox.swift
@@ -1,0 +1,43 @@
+//
+//  WarningMessageBox.swift
+//  Bridge
+//
+//  Created by 정호윤 on 2023/09/26.
+//
+
+import UIKit
+import PinLayout
+import FlexLayout
+
+final class WarningMessageBox: MessageBox {
+    
+    private let warningImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "warning")?
+            .resize(to: CGSize(width: 20, height: 20))
+            .withRenderingMode(.alwaysTemplate)
+        imageView.tintColor = BridgeColor.secondary1
+        return imageView
+    }()
+    
+    init(_ message: String) {
+        super.init(frame: .zero)
+        messageLabel.text = message
+    }
+    
+    // MARK: - Layouts
+    override func configureLayouts() {
+        super.configureLayouts()
+        
+        backgroundView.flex.define { flex in
+            flex.addItem(warningImageView).size(20).marginRight(8)
+            flex.addItem(messageLabel)
+        }
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        backgroundView.pin.all()
+        backgroundView.flex.layout()
+    }
+}

--- a/Bridge/Sources/Presentation/DesignSystem/Component/MessageBox/WarningMessageBox.swift
+++ b/Bridge/Sources/Presentation/DesignSystem/Component/MessageBox/WarningMessageBox.swift
@@ -31,7 +31,7 @@ final class WarningMessageBox: MessageBox {
         
         backgroundView.flex.define { flex in
             flex.addItem(warningImageView).size(20).marginRight(8)
-            flex.addItem(messageLabel)
+            flex.addItem(messageLabel).marginRight(13)
         }
     }
     

--- a/Bridge/Sources/Presentation/DesignSystem/Foundation/BridgeColor.swift
+++ b/Bridge/Sources/Presentation/DesignSystem/Foundation/BridgeColor.swift
@@ -9,14 +9,17 @@ import UIKit
 
 enum BridgeColor {
     // primary
-    static let primary1 = UIColor(red: 255 / 255, green: 145 / 255, blue: 71 / 255, alpha: 1)  // orange
+    /// 주황색
+    static let primary1 = UIColor(red: 255 / 255, green: 145 / 255, blue: 71 / 255, alpha: 1)
     static let primary2 = UIColor(red: 255 / 255, green: 243 / 255, blue: 235 / 255, alpha: 1)
     static let primary3 = UIColor(red: 255 / 255, green: 246 / 255, blue: 240 / 255, alpha: 1)
     
     // secondary
-    static let secondary1 = UIColor(red: 92 / 255, green: 137 / 255, blue: 223 / 255, alpha: 1)  // blue
+    /// 파란색
+    static let secondary1 = UIColor(red: 92 / 255, green: 137 / 255, blue: 223 / 255, alpha: 1)
     static let secondary2 = UIColor(red: 235 / 255, green: 238 / 255, blue: 255 / 255, alpha: 1)
-    static let secondary3 = UIColor(red: 248 / 255, green: 249 / 255, blue: 255 / 255, alpha: 1)
+    static let secondary3 = UIColor(red: 239 / 255, green: 242 / 255, blue: 248 / 255, alpha: 1)
+    static let secondary4 = UIColor(red: 248 / 255, green: 249 / 255, blue: 255 / 255, alpha: 1)
     
     // gray scale
     static let gray1 = UIColor(red: 38 / 255, green: 42 / 255, blue: 52 / 255, alpha: 1)

--- a/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/ChatRoomList/ChatRoomListViewController.swift
@@ -66,6 +66,7 @@ final class ChatRoomListViewController: BaseViewController {
     }
     
     override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         chatRoomListTableView.pin.all()
         placeholderView.pin.all()
     }


### PR DESCRIPTION
## 작업 내용
close #70 
- 슈퍼클래스를 통해 각각의 `MessageBox`들을 정의했습니다.
- `MessageBox`를 상속해 각각의 message box들을 구현했습니다. (피그마에 해당하는 부분)

## 구조도
- 현재 시점의 `BaseView`에 대한 상속 트리입니다.
<img src = "https://github.com/bridge0813/bridge-ios/assets/65343417/7ce0b76b-5ee3-4345-b066-2edfdd860cec" height = 400>

## 스크린샷
- 테스트 용이니 각 컴포넌트만 참고하시면 될듯합니다.
<img src = "https://github.com/bridge0813/bridge-ios/assets/65343417/56e8ad10-08b8-4529-ab4f-3f276bff0651" height = 600>

## 추가 설명
- 피그마의 tool tip은 `TipMessageBox`이고, message box는 `WarningMessageBox`입니다. 
- 각각은 MessageBox를 상속받습니다. 
- 네이밍과 구조를 고려해봤을때 위와같이 하는게 적절해보여서 이렇게 작업했습니다.

## 리뷰 노트
- 이제 회원가입 UI 작업을 할 예정입니다.
