### PR TITLE
이미지 캐싱 구현

### DIFF
--- a/Bridge.xcodeproj/project.pbxproj
+++ b/Bridge.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 		7C3560512B6571E900CF79CE /* MemoryStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3560502B6571E900CF79CE /* MemoryStorage.swift */; };
 		7C3560532B6573D100CF79CE /* DiskStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3560522B6573D100CF79CE /* DiskStorage.swift */; };
 		7C3560552B6576C600CF79CE /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3560542B6576C600CF79CE /* ImageCache.swift */; };
+		7C3560582B6578B500CF79CE /* ImageProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3560572B6578B500CF79CE /* ImageProcessor.swift */; };
 		7C40CBA12AC3E595000F4C9F /* BridgeTechTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C40CBA02AC3E595000F4C9F /* BridgeTechTagButton.swift */; };
 		7C40CBA32AC3E5A8000F4C9F /* BridgeOutlinedTechTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C40CBA22AC3E5A8000F4C9F /* BridgeOutlinedTechTagButton.swift */; };
 		7C40CBBC2AC557BE000F4C9F /* BridgeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C40CBBB2AC557BE000F4C9F /* BridgeButton.swift */; };
@@ -564,6 +565,7 @@
 		7C3560502B6571E900CF79CE /* MemoryStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryStorage.swift; sourceTree = "<group>"; };
 		7C3560522B6573D100CF79CE /* DiskStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskStorage.swift; sourceTree = "<group>"; };
 		7C3560542B6576C600CF79CE /* ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
+		7C3560572B6578B500CF79CE /* ImageProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageProcessor.swift; sourceTree = "<group>"; };
 		7C40CBA02AC3E595000F4C9F /* BridgeTechTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeTechTagButton.swift; sourceTree = "<group>"; };
 		7C40CBA22AC3E5A8000F4C9F /* BridgeOutlinedTechTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeOutlinedTechTagButton.swift; sourceTree = "<group>"; };
 		7C40CBBB2AC557BE000F4C9F /* BridgeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeButton.swift; sourceTree = "<group>"; };
@@ -1758,8 +1760,17 @@
 				7C3560522B6573D100CF79CE /* DiskStorage.swift */,
 				7C35604C2B656FBB00CF79CE /* StorageObject.swift */,
 				7C35604E2B65705D00CF79CE /* StorageExpiration.swift */,
+				7C3560562B65782800CF79CE /* ImageProcessor */,
 			);
 			path = ImageCache;
+			sourceTree = "<group>";
+		};
+		7C3560562B65782800CF79CE /* ImageProcessor */ = {
+			isa = PBXGroup;
+			children = (
+				7C3560572B6578B500CF79CE /* ImageProcessor.swift */,
+			);
+			path = ImageProcessor;
 			sourceTree = "<group>";
 		};
 		7C55E6342ADC06C30018FA5D /* HeaderView */ = {
@@ -2762,6 +2773,7 @@
 			files = (
 				7BE1C6D82ACE852C00C7B730 /* BridgeSetFieldView.swift in Sources */,
 				7CD834BC2B504B4600F3EED7 /* BaseListView.swift in Sources */,
+				7C3560582B6578B500CF79CE /* ImageProcessor.swift in Sources */,
 				7CD834AB2B4D34AE00F3EED7 /* UpdateProfileUseCase.swift in Sources */,
 				7B93B3B72B353B1100912202 /* AlertEndpoint.swift in Sources */,
 				7CA04F212AFE772C007B9191 /* BaseLabel.swift in Sources */,

--- a/Bridge.xcodeproj/project.pbxproj
+++ b/Bridge.xcodeproj/project.pbxproj
@@ -358,7 +358,7 @@
 		7CD834C12B50F95400F3EED7 /* CreateProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD834C02B50F95400F3EED7 /* CreateProfileViewModel.swift */; };
 		7CD834C32B52507F00F3EED7 /* CreateProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD834C22B52507F00F3EED7 /* CreateProfileUseCase.swift */; };
 		7CD834C62B52A02F00F3EED7 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 7CD834C52B52A02F00F3EED7 /* Kingfisher */; };
-		7CD834C82B52A92B00F3EED7 /* UIImageView+KingFisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD834C72B52A92B00F3EED7 /* UIImageView+KingFisher.swift */; };
+		7CD834C82B52A92B00F3EED7 /* UIImageView+ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD834C72B52A92B00F3EED7 /* UIImageView+ImageCache.swift */; };
 		7CDFB6122B2011AB00272F77 /* ManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDFB6112B2011AB00272F77 /* ManagementViewController.swift */; };
 		7CDFB6142B2012AE00272F77 /* ManagementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDFB6132B2012AE00272F77 /* ManagementViewModel.swift */; };
 		7CDFB6162B2015A400272F77 /* ManagementCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDFB6152B2015A400272F77 /* ManagementCoordinator.swift */; };
@@ -706,7 +706,7 @@
 		7CD834BE2B50F7C500F3EED7 /* CreateProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateProfileViewController.swift; sourceTree = "<group>"; };
 		7CD834C02B50F95400F3EED7 /* CreateProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateProfileViewModel.swift; sourceTree = "<group>"; };
 		7CD834C22B52507F00F3EED7 /* CreateProfileUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateProfileUseCase.swift; sourceTree = "<group>"; };
-		7CD834C72B52A92B00F3EED7 /* UIImageView+KingFisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+KingFisher.swift"; sourceTree = "<group>"; };
+		7CD834C72B52A92B00F3EED7 /* UIImageView+ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+ImageCache.swift"; sourceTree = "<group>"; };
 		7CDFB6112B2011AB00272F77 /* ManagementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagementViewController.swift; sourceTree = "<group>"; };
 		7CDFB6132B2012AE00272F77 /* ManagementViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagementViewModel.swift; sourceTree = "<group>"; };
 		7CDFB6152B2015A400272F77 /* ManagementCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagementCoordinator.swift; sourceTree = "<group>"; };
@@ -1513,7 +1513,6 @@
 				7C42701B2AA394EF009BE6AF /* UILabel+.swift */,
 				7C24003F2AB4235800D9D5F1 /* UITextField+.swift */,
 				7B6123852AC1B199006E72C1 /* UIImage+.swift */,
-				7CD834C72B52A92B00F3EED7 /* UIImageView+KingFisher.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1761,6 +1760,7 @@
 				7C35604C2B656FBB00CF79CE /* StorageObject.swift */,
 				7C35604E2B65705D00CF79CE /* StorageExpiration.swift */,
 				7C3560562B65782800CF79CE /* ImageProcessor */,
+				7C3560592B6614A400CF79CE /* Extensions */,
 			);
 			path = ImageCache;
 			sourceTree = "<group>";
@@ -1771,6 +1771,14 @@
 				7C3560572B6578B500CF79CE /* ImageProcessor.swift */,
 			);
 			path = ImageProcessor;
+			sourceTree = "<group>";
+		};
+		7C3560592B6614A400CF79CE /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				7CD834C72B52A92B00F3EED7 /* UIImageView+ImageCache.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		7C55E6342ADC06C30018FA5D /* HeaderView */ = {
@@ -2812,7 +2820,7 @@
 				7B2D76F32AA9941C00E5907B /* SignInViewController.swift in Sources */,
 				7BA36CBF2A9DA44F000DAB02 /* NetworkError.swift in Sources */,
 				7C569CFA2A9F6D5A0063D362 /* FetchAllProjectsUseCase.swift in Sources */,
-				7CD834C82B52A92B00F3EED7 /* UIImageView+KingFisher.swift in Sources */,
+				7CD834C82B52A92B00F3EED7 /* UIImageView+ImageCache.swift in Sources */,
 				7B93B3A42B352C9C00912202 /* AlertCell.swift in Sources */,
 				7B1922CC2AE14E1C00EBDD2E /* UIView+RxKeyboard.swift in Sources */,
 				7C91C9772B3C3B9C002E5ABF /* Profile.swift in Sources */,

--- a/Bridge.xcodeproj/project.pbxproj
+++ b/Bridge.xcodeproj/project.pbxproj
@@ -210,6 +210,7 @@
 		7C3560422B62540000CF79CE /* BaseProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3560412B62540000CF79CE /* BaseProfileViewController.swift */; };
 		7C3560452B6258D400CF79CE /* OtherUserProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3560442B6258D400CF79CE /* OtherUserProfileViewController.swift */; };
 		7C3560472B62590000CF79CE /* OtherUserProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3560462B62590000CF79CE /* OtherUserProfileViewModel.swift */; };
+		7C35604D2B656FBB00CF79CE /* StorageObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C35604C2B656FBB00CF79CE /* StorageObject.swift */; };
 		7C40CBA12AC3E595000F4C9F /* BridgeTechTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C40CBA02AC3E595000F4C9F /* BridgeTechTagButton.swift */; };
 		7C40CBA32AC3E5A8000F4C9F /* BridgeOutlinedTechTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C40CBA22AC3E5A8000F4C9F /* BridgeOutlinedTechTagButton.swift */; };
 		7C40CBBC2AC557BE000F4C9F /* BridgeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C40CBBB2AC557BE000F4C9F /* BridgeButton.swift */; };
@@ -554,6 +555,7 @@
 		7C3560412B62540000CF79CE /* BaseProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseProfileViewController.swift; sourceTree = "<group>"; };
 		7C3560442B6258D400CF79CE /* OtherUserProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherUserProfileViewController.swift; sourceTree = "<group>"; };
 		7C3560462B62590000CF79CE /* OtherUserProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherUserProfileViewModel.swift; sourceTree = "<group>"; };
+		7C35604C2B656FBB00CF79CE /* StorageObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageObject.swift; sourceTree = "<group>"; };
 		7C40CBA02AC3E595000F4C9F /* BridgeTechTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeTechTagButton.swift; sourceTree = "<group>"; };
 		7C40CBA22AC3E5A8000F4C9F /* BridgeOutlinedTechTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeOutlinedTechTagButton.swift; sourceTree = "<group>"; };
 		7C40CBBB2AC557BE000F4C9F /* BridgeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeButton.swift; sourceTree = "<group>"; };
@@ -1295,6 +1297,7 @@
 				7BA36CC52A9E148C000DAB02 /* Extensions */,
 				7B0CFB8A2AD3D19500EA9C0D /* RxExtensions */,
 				7CC719EE2B2777F800CFA827 /* Typealias */,
+				7C35604B2B656F8700CF79CE /* ImageCache */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1737,6 +1740,14 @@
 				7C3560442B6258D400CF79CE /* OtherUserProfileViewController.swift */,
 			);
 			path = Profile;
+			sourceTree = "<group>";
+		};
+		7C35604B2B656F8700CF79CE /* ImageCache */ = {
+			isa = PBXGroup;
+			children = (
+				7C35604C2B656FBB00CF79CE /* StorageObject.swift */,
+			);
+			path = ImageCache;
 			sourceTree = "<group>";
 		};
 		7C55E6342ADC06C30018FA5D /* HeaderView */ = {
@@ -2934,6 +2945,7 @@
 				7C55E64E2AE44BCF0018FA5D /* CompositionalLayoutConfiguration.swift in Sources */,
 				7CDFB6162B2015A400272F77 /* ManagementCoordinator.swift in Sources */,
 				7CDFB6142B2012AE00272F77 /* ManagementViewModel.swift in Sources */,
+				7C35604D2B656FBB00CF79CE /* StorageObject.swift in Sources */,
 				7CD834A92B4BEB3800F3EED7 /* RxDocumentInteractionControllerDelegateProxy.swift in Sources */,
 				7BA5336B2B0EED5E00E69BFB /* ObserveMessageUseCase.swift in Sources */,
 				7C55E64A2AE44B5F0018FA5D /* HotProjectCell.swift in Sources */,

--- a/Bridge.xcodeproj/project.pbxproj
+++ b/Bridge.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		7C35604F2B65705D00CF79CE /* StorageExpiration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C35604E2B65705D00CF79CE /* StorageExpiration.swift */; };
 		7C3560512B6571E900CF79CE /* MemoryStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3560502B6571E900CF79CE /* MemoryStorage.swift */; };
 		7C3560532B6573D100CF79CE /* DiskStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3560522B6573D100CF79CE /* DiskStorage.swift */; };
+		7C3560552B6576C600CF79CE /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3560542B6576C600CF79CE /* ImageCache.swift */; };
 		7C40CBA12AC3E595000F4C9F /* BridgeTechTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C40CBA02AC3E595000F4C9F /* BridgeTechTagButton.swift */; };
 		7C40CBA32AC3E5A8000F4C9F /* BridgeOutlinedTechTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C40CBA22AC3E5A8000F4C9F /* BridgeOutlinedTechTagButton.swift */; };
 		7C40CBBC2AC557BE000F4C9F /* BridgeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C40CBBB2AC557BE000F4C9F /* BridgeButton.swift */; };
@@ -562,6 +563,7 @@
 		7C35604E2B65705D00CF79CE /* StorageExpiration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageExpiration.swift; sourceTree = "<group>"; };
 		7C3560502B6571E900CF79CE /* MemoryStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryStorage.swift; sourceTree = "<group>"; };
 		7C3560522B6573D100CF79CE /* DiskStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskStorage.swift; sourceTree = "<group>"; };
+		7C3560542B6576C600CF79CE /* ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		7C40CBA02AC3E595000F4C9F /* BridgeTechTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeTechTagButton.swift; sourceTree = "<group>"; };
 		7C40CBA22AC3E5A8000F4C9F /* BridgeOutlinedTechTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeOutlinedTechTagButton.swift; sourceTree = "<group>"; };
 		7C40CBBB2AC557BE000F4C9F /* BridgeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeButton.swift; sourceTree = "<group>"; };
@@ -1751,10 +1753,11 @@
 		7C35604B2B656F8700CF79CE /* ImageCache */ = {
 			isa = PBXGroup;
 			children = (
-				7C35604C2B656FBB00CF79CE /* StorageObject.swift */,
-				7C35604E2B65705D00CF79CE /* StorageExpiration.swift */,
+				7C3560542B6576C600CF79CE /* ImageCache.swift */,
 				7C3560502B6571E900CF79CE /* MemoryStorage.swift */,
 				7C3560522B6573D100CF79CE /* DiskStorage.swift */,
+				7C35604C2B656FBB00CF79CE /* StorageObject.swift */,
+				7C35604E2B65705D00CF79CE /* StorageExpiration.swift */,
 			);
 			path = ImageCache;
 			sourceTree = "<group>";
@@ -3036,6 +3039,7 @@
 				7C569CF32A9F67C60063D362 /* ProjectPreview.swift in Sources */,
 				7C24002A2AB1B87400D9D5F1 /* ProjectDescriptionInputViewModel.swift in Sources */,
 				7C56E16F2B145E3000454F5E /* FieldRequestDTO.swift in Sources */,
+				7C3560552B6576C600CF79CE /* ImageCache.swift in Sources */,
 				7B1E5ABC2ADCFD790053E9B3 /* ChannelViewController.swift in Sources */,
 				7C3560532B6573D100CF79CE /* DiskStorage.swift in Sources */,
 				7BA36C9F2A9C6229000DAB02 /* LeaveChannelUseCase.swift in Sources */,

--- a/Bridge.xcodeproj/project.pbxproj
+++ b/Bridge.xcodeproj/project.pbxproj
@@ -357,7 +357,6 @@
 		7CD834BF2B50F7C500F3EED7 /* CreateProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD834BE2B50F7C500F3EED7 /* CreateProfileViewController.swift */; };
 		7CD834C12B50F95400F3EED7 /* CreateProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD834C02B50F95400F3EED7 /* CreateProfileViewModel.swift */; };
 		7CD834C32B52507F00F3EED7 /* CreateProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD834C22B52507F00F3EED7 /* CreateProfileUseCase.swift */; };
-		7CD834C62B52A02F00F3EED7 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 7CD834C52B52A02F00F3EED7 /* Kingfisher */; };
 		7CD834C82B52A92B00F3EED7 /* UIImageView+ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD834C72B52A92B00F3EED7 /* UIImageView+ImageCache.swift */; };
 		7CDFB6122B2011AB00272F77 /* ManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDFB6112B2011AB00272F77 /* ManagementViewController.swift */; };
 		7CDFB6142B2012AE00272F77 /* ManagementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDFB6132B2012AE00272F77 /* ManagementViewModel.swift */; };
@@ -778,7 +777,6 @@
 				7BA96EC12B28140B000D48AE /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */,
 				7B71E7612A933C18001B5D2C /* FlexLayoutYoga in Frameworks */,
 				7BA96EC32B28140B000D48AE /* FirebaseAppCheck in Frameworks */,
-				7CD834C62B52A02F00F3EED7 /* Kingfisher in Frameworks */,
 				7B1D9FB52ADE11A9005F42D9 /* Starscream in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2680,7 +2678,6 @@
 				7BA96EEA2B28140B000D48AE /* FirebaseRemoteConfigSwift */,
 				7BA96EEC2B28140B000D48AE /* FirebaseStorage */,
 				7BA96EEE2B28140B000D48AE /* FirebaseStorageCombine-Community */,
-				7CD834C52B52A02F00F3EED7 /* Kingfisher */,
 			);
 			productName = Bridge;
 			productReference = 7B71E73D2A9330C6001B5D2C /* Bridge.app */;
@@ -2717,7 +2714,6 @@
 				7B1D9FB32ADE11A9005F42D9 /* XCRemoteSwiftPackageReference "Starscream" */,
 				7CA04F6A2B0C5D29007B9191 /* XCRemoteSwiftPackageReference "lottie-spm" */,
 				7BA96EB92B28140B000D48AE /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
-				7CD834C42B52A02E00F3EED7 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 			);
 			productRefGroup = 7B71E73E2A9330C6001B5D2C /* Products */;
 			projectDirPath = "";
@@ -3385,14 +3381,6 @@
 				minimumVersion = 4.0.0;
 			};
 		};
-		7CD834C42B52A02E00F3EED7 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/onevcat/Kingfisher.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 7.10.2;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -3580,11 +3568,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 7CA04F6A2B0C5D29007B9191 /* XCRemoteSwiftPackageReference "lottie-spm" */;
 			productName = Lottie;
-		};
-		7CD834C52B52A02F00F3EED7 /* Kingfisher */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 7CD834C42B52A02E00F3EED7 /* XCRemoteSwiftPackageReference "Kingfisher" */;
-			productName = Kingfisher;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Bridge.xcodeproj/project.pbxproj
+++ b/Bridge.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 		7C35604D2B656FBB00CF79CE /* StorageObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C35604C2B656FBB00CF79CE /* StorageObject.swift */; };
 		7C35604F2B65705D00CF79CE /* StorageExpiration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C35604E2B65705D00CF79CE /* StorageExpiration.swift */; };
 		7C3560512B6571E900CF79CE /* MemoryStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3560502B6571E900CF79CE /* MemoryStorage.swift */; };
+		7C3560532B6573D100CF79CE /* DiskStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3560522B6573D100CF79CE /* DiskStorage.swift */; };
 		7C40CBA12AC3E595000F4C9F /* BridgeTechTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C40CBA02AC3E595000F4C9F /* BridgeTechTagButton.swift */; };
 		7C40CBA32AC3E5A8000F4C9F /* BridgeOutlinedTechTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C40CBA22AC3E5A8000F4C9F /* BridgeOutlinedTechTagButton.swift */; };
 		7C40CBBC2AC557BE000F4C9F /* BridgeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C40CBBB2AC557BE000F4C9F /* BridgeButton.swift */; };
@@ -560,6 +561,7 @@
 		7C35604C2B656FBB00CF79CE /* StorageObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageObject.swift; sourceTree = "<group>"; };
 		7C35604E2B65705D00CF79CE /* StorageExpiration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageExpiration.swift; sourceTree = "<group>"; };
 		7C3560502B6571E900CF79CE /* MemoryStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryStorage.swift; sourceTree = "<group>"; };
+		7C3560522B6573D100CF79CE /* DiskStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskStorage.swift; sourceTree = "<group>"; };
 		7C40CBA02AC3E595000F4C9F /* BridgeTechTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeTechTagButton.swift; sourceTree = "<group>"; };
 		7C40CBA22AC3E5A8000F4C9F /* BridgeOutlinedTechTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeOutlinedTechTagButton.swift; sourceTree = "<group>"; };
 		7C40CBBB2AC557BE000F4C9F /* BridgeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeButton.swift; sourceTree = "<group>"; };
@@ -1752,6 +1754,7 @@
 				7C35604C2B656FBB00CF79CE /* StorageObject.swift */,
 				7C35604E2B65705D00CF79CE /* StorageExpiration.swift */,
 				7C3560502B6571E900CF79CE /* MemoryStorage.swift */,
+				7C3560522B6573D100CF79CE /* DiskStorage.swift */,
 			);
 			path = ImageCache;
 			sourceTree = "<group>";
@@ -3034,6 +3037,7 @@
 				7C24002A2AB1B87400D9D5F1 /* ProjectDescriptionInputViewModel.swift in Sources */,
 				7C56E16F2B145E3000454F5E /* FieldRequestDTO.swift in Sources */,
 				7B1E5ABC2ADCFD790053E9B3 /* ChannelViewController.swift in Sources */,
+				7C3560532B6573D100CF79CE /* DiskStorage.swift in Sources */,
 				7BA36C9F2A9C6229000DAB02 /* LeaveChannelUseCase.swift in Sources */,
 				7CA04F692B0A6F02007B9191 /* CreateProjectUseCase.swift in Sources */,
 				7CC719F22B277A3500CFA827 /* ApplicantProfile.swift in Sources */,

--- a/Bridge.xcodeproj/project.pbxproj
+++ b/Bridge.xcodeproj/project.pbxproj
@@ -211,6 +211,7 @@
 		7C3560452B6258D400CF79CE /* OtherUserProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3560442B6258D400CF79CE /* OtherUserProfileViewController.swift */; };
 		7C3560472B62590000CF79CE /* OtherUserProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3560462B62590000CF79CE /* OtherUserProfileViewModel.swift */; };
 		7C35604D2B656FBB00CF79CE /* StorageObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C35604C2B656FBB00CF79CE /* StorageObject.swift */; };
+		7C35604F2B65705D00CF79CE /* StorageExpiration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C35604E2B65705D00CF79CE /* StorageExpiration.swift */; };
 		7C40CBA12AC3E595000F4C9F /* BridgeTechTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C40CBA02AC3E595000F4C9F /* BridgeTechTagButton.swift */; };
 		7C40CBA32AC3E5A8000F4C9F /* BridgeOutlinedTechTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C40CBA22AC3E5A8000F4C9F /* BridgeOutlinedTechTagButton.swift */; };
 		7C40CBBC2AC557BE000F4C9F /* BridgeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C40CBBB2AC557BE000F4C9F /* BridgeButton.swift */; };
@@ -556,6 +557,7 @@
 		7C3560442B6258D400CF79CE /* OtherUserProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherUserProfileViewController.swift; sourceTree = "<group>"; };
 		7C3560462B62590000CF79CE /* OtherUserProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherUserProfileViewModel.swift; sourceTree = "<group>"; };
 		7C35604C2B656FBB00CF79CE /* StorageObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageObject.swift; sourceTree = "<group>"; };
+		7C35604E2B65705D00CF79CE /* StorageExpiration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageExpiration.swift; sourceTree = "<group>"; };
 		7C40CBA02AC3E595000F4C9F /* BridgeTechTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeTechTagButton.swift; sourceTree = "<group>"; };
 		7C40CBA22AC3E5A8000F4C9F /* BridgeOutlinedTechTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeOutlinedTechTagButton.swift; sourceTree = "<group>"; };
 		7C40CBBB2AC557BE000F4C9F /* BridgeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeButton.swift; sourceTree = "<group>"; };
@@ -1746,6 +1748,7 @@
 			isa = PBXGroup;
 			children = (
 				7C35604C2B656FBB00CF79CE /* StorageObject.swift */,
+				7C35604E2B65705D00CF79CE /* StorageExpiration.swift */,
 			);
 			path = ImageCache;
 			sourceTree = "<group>";
@@ -2850,6 +2853,7 @@
 				7BA36C982A9C503C000DAB02 /* FetchChannelsUseCase.swift in Sources */,
 				7C91C9752B3BDAF2002E5ABF /* ProfileTechStackCell.swift in Sources */,
 				7B93AAA82B21997300650EA5 /* UnreadMessageCountView.swift in Sources */,
+				7C35604F2B65705D00CF79CE /* StorageExpiration.swift in Sources */,
 				7CE080492AD79ADD00230C86 /* FieldCategoryAnchorButton.swift in Sources */,
 				7CA04F252AFE7B6E007B9191 /* BridgeLinedChip.swift in Sources */,
 				7B93B3AC2B35378600912202 /* RemoveAlertUseCase.swift in Sources */,

--- a/Bridge.xcodeproj/project.pbxproj
+++ b/Bridge.xcodeproj/project.pbxproj
@@ -212,6 +212,7 @@
 		7C3560472B62590000CF79CE /* OtherUserProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3560462B62590000CF79CE /* OtherUserProfileViewModel.swift */; };
 		7C35604D2B656FBB00CF79CE /* StorageObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C35604C2B656FBB00CF79CE /* StorageObject.swift */; };
 		7C35604F2B65705D00CF79CE /* StorageExpiration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C35604E2B65705D00CF79CE /* StorageExpiration.swift */; };
+		7C3560512B6571E900CF79CE /* MemoryStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3560502B6571E900CF79CE /* MemoryStorage.swift */; };
 		7C40CBA12AC3E595000F4C9F /* BridgeTechTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C40CBA02AC3E595000F4C9F /* BridgeTechTagButton.swift */; };
 		7C40CBA32AC3E5A8000F4C9F /* BridgeOutlinedTechTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C40CBA22AC3E5A8000F4C9F /* BridgeOutlinedTechTagButton.swift */; };
 		7C40CBBC2AC557BE000F4C9F /* BridgeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C40CBBB2AC557BE000F4C9F /* BridgeButton.swift */; };
@@ -558,6 +559,7 @@
 		7C3560462B62590000CF79CE /* OtherUserProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherUserProfileViewModel.swift; sourceTree = "<group>"; };
 		7C35604C2B656FBB00CF79CE /* StorageObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageObject.swift; sourceTree = "<group>"; };
 		7C35604E2B65705D00CF79CE /* StorageExpiration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageExpiration.swift; sourceTree = "<group>"; };
+		7C3560502B6571E900CF79CE /* MemoryStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryStorage.swift; sourceTree = "<group>"; };
 		7C40CBA02AC3E595000F4C9F /* BridgeTechTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeTechTagButton.swift; sourceTree = "<group>"; };
 		7C40CBA22AC3E5A8000F4C9F /* BridgeOutlinedTechTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeOutlinedTechTagButton.swift; sourceTree = "<group>"; };
 		7C40CBBB2AC557BE000F4C9F /* BridgeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeButton.swift; sourceTree = "<group>"; };
@@ -1749,6 +1751,7 @@
 			children = (
 				7C35604C2B656FBB00CF79CE /* StorageObject.swift */,
 				7C35604E2B65705D00CF79CE /* StorageExpiration.swift */,
+				7C3560502B6571E900CF79CE /* MemoryStorage.swift */,
 			);
 			path = ImageCache;
 			sourceTree = "<group>";
@@ -3040,6 +3043,7 @@
 				7B922CFC2AD02EE400F3A336 /* SignUpUseCase.swift in Sources */,
 				7C40CBCA2AC6B597000F4C9F /* BridgeCreateProjectButton.swift in Sources */,
 				7B9C31AF2B07761C007E36B2 /* DefaultStompService.swift in Sources */,
+				7C3560512B6571E900CF79CE /* MemoryStorage.swift in Sources */,
 				7C8CC41C2AF522A10032F237 /* BridgeBasePopUpView.swift in Sources */,
 				7CBDE2672B3FDAB800518AA9 /* ReferenceFileCell.swift in Sources */,
 				7BA36C8E2A9C4B33000DAB02 /* ViewModelType.swift in Sources */,

--- a/Bridge.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bridge.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -91,15 +91,6 @@
       }
     },
     {
-      "identity" : "kingfisher",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/onevcat/Kingfisher.git",
-      "state" : {
-        "revision" : "3ec0ab0bca4feb56e8b33e289c9496e89059dd08",
-        "version" : "7.10.2"
-      }
-    },
-    {
       "identity" : "leveldb",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/leveldb.git",

--- a/Bridge/Sources/Presentation/Common/Extensions/UIImageView+KingFisher.swift
+++ b/Bridge/Sources/Presentation/Common/Extensions/UIImageView+KingFisher.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import Kingfisher
 
 extension UIImageView {
     /// URL을 가지고 이미지를 다운로드하여 적용하는 메서드
@@ -15,31 +14,22 @@ extension UIImageView {
     /// - Parameter size: 다운샘플링 할 이미지의 크기
     /// - Parameter placeholderImage: 이미지 적용에 실패했을 경우, 적용되는 플레이스홀더 이미지
     func setImage(
-        with urlString: URLString?,
+        from urlString: URLString?,
         size: CGSize,
         placeholderImage: UIImage? = UIImage(named: "profile.small")
     ) {
-        guard let urlString else { return self.image = placeholderImage }
-        let url = URL(string: urlString)
+        // 유효하지 않은 URL인 경우 플레이스홀더를 이미지로 설정
+        guard let urlString, let url = URL(string: urlString) else {
+            image = placeholderImage
+            return
+        }
         
-        // 다운샘플링 후 Radius 적용
-        let processor = DownsamplingImageProcessor(size: size)
-        |> RoundCornerImageProcessor(cornerRadius: self.layer.cornerRadius)
-        
-        // 이미지 처리 옵션
-        let options: KingfisherOptionsInfo = [
-            .scaleFactor(UIScreen.main.scale),
-            .processor(processor),
-            .transition(.fade(0.4)),
-            .cacheOriginalImage
-        ]
-        
-        // 다운로드 작업이 진행중일 때, 이미지 뷰에 인디케이터 설정.
-        self.kf.indicatorType = .activity
-        self.kf.setImage(with: url, options: options) { [weak self] result in
-            if case .failure(let error) = result {
-                print(error.localizedDescription)
-                self?.image = placeholderImage
+        ImageCache.shared.load(url: url, withOption: .downsampling(size: size)) { [weak self] image in
+            guard let self else { return }
+            
+            UIView.transition(with: self, duration: 0.3, options: .transitionCrossDissolve) {
+                // 이미지가 없으면 플레이스홀더 적용, 있으면 해당 이미지 적용
+                self.image = image == nil ? placeholderImage : image
             }
         }
     }

--- a/Bridge/Sources/Presentation/Common/Extensions/UIImageView+KingFisher.swift
+++ b/Bridge/Sources/Presentation/Common/Extensions/UIImageView+KingFisher.swift
@@ -24,13 +24,37 @@ extension UIImageView {
             return
         }
         
+        // 기존 이미지 제거
+        image = nil
+        
+        // 인디케이터 설정
+        let indicator = addActivityIndicator()
+        indicator.startAnimating()
+        
         ImageCache.shared.load(url: url, withOption: .downsampling(size: size)) { [weak self] image in
             guard let self else { return }
             
             UIView.transition(with: self, duration: 0.3, options: .transitionCrossDissolve) {
+                indicator.removeFromSuperview()
+                
                 // 이미지가 없으면 플레이스홀더 적용, 있으면 해당 이미지 적용
                 self.image = image == nil ? placeholderImage : image
             }
         }
+    }
+    
+    /// 이미지 로드 중 보여 줄  인디케이터를 설정하는 메서드
+    private func addActivityIndicator() -> UIActivityIndicatorView {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.hidesWhenStopped = true
+        addSubview(indicator)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            indicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+            indicator.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+        
+        return indicator
     }
 }

--- a/Bridge/Sources/Presentation/Common/ImageCache/DiskStorage.swift
+++ b/Bridge/Sources/Presentation/Common/ImageCache/DiskStorage.swift
@@ -5,7 +5,7 @@
 //  Created by 엄지호 on 1/28/24.
 //
 
-import Foundation
+import UIKit
 
 /// 디스크 저장소
 final class DiskStorage {
@@ -16,6 +16,7 @@ final class DiskStorage {
     // MARK: - Init
     init() {
         createDirectory()
+        observeBackgroundNotification()
         directoryURL = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first?
             .appendingPathComponent("Bridge")
     }
@@ -127,5 +128,21 @@ extension DiskStorage {
                 print("디렉토리 내 만료된 데이터 제거 실패: \(error.localizedDescription)")
             }
         }
+    }
+}
+
+// MARK: - Notification
+extension DiskStorage {
+    private func observeBackgroundNotification() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didEnterBackground),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+    }
+    
+    @objc private func didEnterBackground() {
+        removeExpired()
     }
 }

--- a/Bridge/Sources/Presentation/Common/ImageCache/DiskStorage.swift
+++ b/Bridge/Sources/Presentation/Common/ImageCache/DiskStorage.swift
@@ -30,8 +30,14 @@ final class DiskStorage {
             // 디스크 캐싱
             try storageObject.imageData.write(to: resultURL)
             
+            // 속성 정의(만료날짜) 및 저장
+            let attributes: [FileAttributeKey: Any] = [
+                .modificationDate: storageObject.estimatedExpiration.fileAttributeDate
+            ]
+            try fileManager.setAttributes(attributes, ofItemAtPath: resultURL.path)
+            
         } catch {
-            print("데이터 저장 실패  \(error.localizedDescription)")
+            print("데이터 및 속성 저장 실패  \(error.localizedDescription)")
         }
     }
     

--- a/Bridge/Sources/Presentation/Common/ImageCache/DiskStorage.swift
+++ b/Bridge/Sources/Presentation/Common/ImageCache/DiskStorage.swift
@@ -1,0 +1,80 @@
+//
+//  DiskStorage.swift
+//  Bridge
+//
+//  Created by 엄지호 on 1/28/24.
+//
+
+import Foundation
+
+/// 디스크 저장소
+final class DiskStorage {
+    // MARK: - Property
+    private let fileManager = FileManager.default
+    private var directoryURL: URL?  // 이미지가 저장되어 있는 디렉토리 URL
+    
+    // MARK: - Init
+    init() {
+        createDirectory()
+        directoryURL = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first?
+            .appendingPathComponent("Bridge")
+    }
+    
+    // MARK: - CRUD
+    /// 데이터 저장
+    func store(_ imageData: Data, identifier: String) {
+        guard let resultURL = directoryURL?.appendingPathComponent(identifier) else { return }
+        let storageObject = StorageObject(imageData: imageData, expiration: .days(7))
+        
+        do {
+            // 디스크 캐싱
+            try storageObject.imageData.write(to: resultURL)
+            
+        } catch {
+            print("데이터 저장 실패  \(error.localizedDescription)")
+        }
+    }
+    
+    /// 데이터 조회
+    func value(with identifier: String) -> Data? {
+        guard let resultURL = directoryURL?.appendingPathComponent(identifier) else {
+            return nil
+        }
+        
+        guard fileManager.fileExists(atPath: resultURL.path) else {
+            return nil
+        }
+        
+        return try? Data(contentsOf: resultURL)
+    }
+    
+    /// 저장된 모든 데이터 제거
+    func removeAll() {
+        guard let directoryURL else { return }
+        
+        do {
+            try fileManager.removeItem(at: directoryURL)
+            print("저장된 디렉토리 제거 완료")
+            
+        } catch {
+            print("저장된 디렉토리 제거 실패: \(error)")
+        }
+    }
+    
+    // MARK: - Helpers
+    /// 데이터를 저장할 디렉토리 생성(존재하지 않을 경우)
+    private func createDirectory() {
+        guard let directoryURL else { return }
+        
+        if !fileManager.fileExists(atPath: directoryURL.path) {
+            do {
+                try fileManager.createDirectory(
+                    atPath: directoryURL.path, withIntermediateDirectories: true
+                )
+                
+            } catch {
+                print("디렉토리 생성 실패: \(error)")
+            }
+        }
+    }
+}

--- a/Bridge/Sources/Presentation/Common/ImageCache/Extensions/UIImageView+ImageCache.swift
+++ b/Bridge/Sources/Presentation/Common/ImageCache/Extensions/UIImageView+ImageCache.swift
@@ -1,5 +1,5 @@
 //
-//  UIImageView+KingFisher.swift
+//  UIImageView+ImageCache.swift
 //  Bridge
 //
 //  Created by 엄지호 on 1/13/24.

--- a/Bridge/Sources/Presentation/Common/ImageCache/ImageCache.swift
+++ b/Bridge/Sources/Presentation/Common/ImageCache/ImageCache.swift
@@ -1,0 +1,69 @@
+//
+//  ImageCache.swift
+//  Bridge
+//
+//  Created by 엄지호 on 1/28/24.
+//
+
+import UIKit
+
+final class ImageCache {
+    // MARK: - Property
+    static let shared = ImageCache()
+    private let memoryStorage = MemoryStorage()
+    private let diskStorage = DiskStorage()
+    
+    // MARK: - Init
+    private init() { }
+    
+    // MARK: - Load
+    func load(url: URL, downsampleSize: CGSize, completion: @escaping (UIImage?) -> Void) {
+        // 1. 캐시 메모리에서 이미지 데이터 찾기
+        if let cachedImageData = memoryStorage.value(forKey: url as NSURL) {
+            // 이미지 작업 후 리턴
+            return
+        }
+        
+        // 2. 디스크 메모리에서 이미지 데이터 찾기
+        if let diskImageData = diskStorage.value(with: url.lastPathComponent) {
+            // 이미지 작업 후 리턴
+            memoryStorage.store(diskImageData, forKey: url as NSURL)
+            return
+        }
+        
+        // 3. 이미지 다운로드
+        URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
+            guard let self else { return }
+            
+            if let error {
+                print(error.localizedDescription)
+                DispatchQueue.main.async {
+                    completion(nil)
+                }
+                return
+            }
+            
+            guard let data else {
+                DispatchQueue.main.async {
+                    completion(nil)
+                }
+                return
+            }
+        
+            // 이미지 작업 후 리턴
+            
+            self.memoryStorage.store(data, forKey: url as NSURL)
+            self.diskStorage.store(data, identifier: url.lastPathComponent)
+            
+        }
+        .resume()
+    }
+    
+    func clearMemoryCache() {
+        memoryStorage.removeAll()
+    }
+    
+    func clearDiskCache() {
+        diskStorage.removeAll()
+    }
+}

--- a/Bridge/Sources/Presentation/Common/ImageCache/ImageProcessor/ImageProcessor.swift
+++ b/Bridge/Sources/Presentation/Common/ImageCache/ImageProcessor/ImageProcessor.swift
@@ -1,0 +1,52 @@
+//
+//  ImageProcessor.swift
+//  Bridge
+//
+//  Created by 엄지호 on 1/28/24.
+//
+
+import UIKit
+
+enum ImageProcessOption {
+    case downsampling(size: CGSize)
+}
+
+protocol ImageProcessor {
+    func process(data: Data) -> UIImage?
+}
+
+struct DownsamplingImageProcessor: ImageProcessor {
+    let size: CGSize
+    
+    init(size: CGSize) {
+        self.size = size
+    }
+    
+    func process(data: Data) -> UIImage? {
+        // 이미지 소스를 생성할 때, 캐시를 사용할 지 여부를 결정
+        let imageSourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+        
+        // CGImageSource 객체를 생성
+        guard let imageSource = CGImageSourceCreateWithData(data as CFData, imageSourceOptions) else {
+            return nil
+        }
+        
+        // 최대 픽셀 크기를 계산(이미지의 최종 크기를 결정)
+        let maxDimensionInPixels = max(size.width, size.height) * UIScreen.main.scale
+        
+        // 다운샘플링에서 사용할 옵션
+        let downsampleOptions: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxDimensionInPixels
+        ]
+        
+        // 썸네일 생성
+        guard let downsampledImage = CGImageSourceCreateThumbnailAtIndex(
+            imageSource, 0, downsampleOptions as CFDictionary
+        ) else { return nil }
+        
+        return UIImage(cgImage: downsampledImage, scale: UIScreen.main.scale, orientation: .up)
+    }
+}

--- a/Bridge/Sources/Presentation/Common/ImageCache/MemoryStorage.swift
+++ b/Bridge/Sources/Presentation/Common/ImageCache/MemoryStorage.swift
@@ -1,0 +1,41 @@
+//
+//  MemoryStorage.swift
+//  Bridge
+//
+//  Created by 엄지호 on 1/28/24.
+//
+
+import Foundation
+
+/// 캐시 메모리 저장소
+final class MemoryStorage {
+    // MARK: - Property
+    private let storage: NSCache = {
+        let cache = NSCache<NSURL, StorageObject>()
+        // 캐시 최대 용량 설정
+        let totalMemory = ProcessInfo.processInfo.physicalMemory
+        let costLimit = totalMemory / 4
+        cache.totalCostLimit = (costLimit > Int.max) ? Int.max : Int(costLimit)
+        return cache
+    }()
+    
+    // MARK: - Init
+    init() { }
+    
+    // MARK: - CRUD
+    /// 데이터 저장
+    func store(_ imageData: Data, forKey key: NSURL) {
+        let storageObject = StorageObject(imageData: imageData, expiration: .seconds(300))
+        storage.setObject(storageObject, forKey: key)
+    }
+    
+    /// 데이터 조회
+    func value(forKey key: NSURL) -> Data? {
+        return storage.object(forKey: key)?.imageData
+    }
+    
+    /// 저장된 모든 데이터 제거
+    func removeAll() {
+        storage.removeAllObjects()
+    }
+}

--- a/Bridge/Sources/Presentation/Common/ImageCache/MemoryStorage.swift
+++ b/Bridge/Sources/Presentation/Common/ImageCache/MemoryStorage.swift
@@ -22,7 +22,13 @@ final class MemoryStorage {
     private var keys = Set<NSURL>()  // 캐시에 저장된 객체들의 키를 추적하는 데 사용
     
     // MARK: - Init
-    init() { }
+    init() { 
+        // 240초 주기로 만료된 데이터를 제거
+        Timer.scheduledTimer(withTimeInterval: 240, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            self.removeExpired()
+        }
+    }
     
     // MARK: - CRUD
     /// 데이터 저장
@@ -41,5 +47,21 @@ final class MemoryStorage {
     func removeAll() {
         storage.removeAllObjects()
         keys.removeAll()
+    }
+    
+    /// 만료된 데이터 제거
+    private func removeExpired() {
+        for key in keys {
+            guard let object = storage.object(forKey: key) else {
+                keys.remove(key)
+                continue
+            }
+            
+            // 데이터가 만료된 경우 제거
+            if object.isExpired {
+                storage.removeObject(forKey: key)
+                keys.remove(key)
+            }
+        }
     }
 }

--- a/Bridge/Sources/Presentation/Common/ImageCache/MemoryStorage.swift
+++ b/Bridge/Sources/Presentation/Common/ImageCache/MemoryStorage.swift
@@ -19,6 +19,8 @@ final class MemoryStorage {
         return cache
     }()
     
+    private var keys = Set<NSURL>()  // 캐시에 저장된 객체들의 키를 추적하는 데 사용
+    
     // MARK: - Init
     init() { }
     
@@ -27,6 +29,7 @@ final class MemoryStorage {
     func store(_ imageData: Data, forKey key: NSURL) {
         let storageObject = StorageObject(imageData: imageData, expiration: .seconds(300))
         storage.setObject(storageObject, forKey: key)
+        keys.insert(key)
     }
     
     /// 데이터 조회
@@ -37,5 +40,6 @@ final class MemoryStorage {
     /// 저장된 모든 데이터 제거
     func removeAll() {
         storage.removeAllObjects()
+        keys.removeAll()
     }
 }

--- a/Bridge/Sources/Presentation/Common/ImageCache/StorageExpiration.swift
+++ b/Bridge/Sources/Presentation/Common/ImageCache/StorageExpiration.swift
@@ -1,0 +1,26 @@
+//
+//  StorageExpiration.swift
+//  Bridge
+//
+//  Created by 엄지호 on 1/28/24.
+//
+
+import Foundation
+
+/// 캐시된 데이터의 만료를 정의
+enum StorageExpiration {
+    case seconds(TimeInterval)
+    case days(Int)
+    
+    func estimatedExpirationSince() -> Date {
+        switch self {
+        case .seconds(let seconds):
+            return Date().addingTimeInterval(seconds)
+            
+        case .days(let days):
+            // 하루를 초 단위로 환산 * 일 수
+            let duration = TimeInterval(86_400) * TimeInterval(days)
+            return Date().addingTimeInterval(duration)
+        }
+    }
+}

--- a/Bridge/Sources/Presentation/Common/ImageCache/StorageObject.swift
+++ b/Bridge/Sources/Presentation/Common/ImageCache/StorageObject.swift
@@ -1,0 +1,17 @@
+//
+//  StorageObject.swift
+//  Bridge
+//
+//  Created by 엄지호 on 1/28/24.
+//
+
+import Foundation
+
+// 메모리와 디스크에 저장할 객체
+final class StorageObject {
+    let imageData: Data
+    
+    init(imageData: Data) {
+        self.imageData = imageData
+    }
+}

--- a/Bridge/Sources/Presentation/Common/ImageCache/StorageObject.swift
+++ b/Bridge/Sources/Presentation/Common/ImageCache/StorageObject.swift
@@ -29,4 +29,9 @@ extension Date {
     var isPast: Bool {
         return timeIntervalSince(Date()) <= 0
     }
+    
+    /// 파일 속성에 사용될 날짜를 반환(처리 일관성을 위해)
+    var fileAttributeDate: Date {
+        return Date(timeIntervalSince1970: ceil(timeIntervalSince1970))
+    }
 }

--- a/Bridge/Sources/Presentation/Common/ImageCache/StorageObject.swift
+++ b/Bridge/Sources/Presentation/Common/ImageCache/StorageObject.swift
@@ -10,8 +10,23 @@ import Foundation
 // 메모리와 디스크에 저장할 객체
 final class StorageObject {
     let imageData: Data
+    private let expiration: StorageExpiration
+    var estimatedExpiration: Date  // 만료 날짜
     
-    init(imageData: Data) {
+    init(imageData: Data, expiration: StorageExpiration) {
         self.imageData = imageData
+        self.expiration = expiration
+        self.estimatedExpiration = expiration.estimatedExpirationSince()
+    }
+    
+    var isExpired: Bool {
+        return estimatedExpiration.isPast
+    }
+}
+
+extension Date {
+    /// 현재 시간과 비교하여, 과거의 날짜(만료됨)인지 여부를 반환
+    var isPast: Bool {
+        return timeIntervalSince(Date()) <= 0
     }
 }

--- a/Bridge/Sources/Presentation/Tab/Chat/Channel/Views/ChannelProfileView.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/Channel/Views/ChannelProfileView.swift
@@ -51,7 +51,7 @@ extension ChannelProfileView {
     func configure(with channel: Channel) {
         nameButton.setTitle(channel.name, for: .normal)
         imageView.setImage(
-            with: channel.imageURL,
+            from: channel.imageURL,
             size: CGSize(width: 28, height: 28),
             placeholderImage: UIImage(named: "profile")
         )

--- a/Bridge/Sources/Presentation/Tab/Chat/ChannelList/Cell/ChannelCell.swift
+++ b/Bridge/Sources/Presentation/Tab/Chat/ChannelList/Cell/ChannelCell.swift
@@ -82,7 +82,7 @@ final class ChannelCell: BaseTableViewCell {
 extension ChannelCell {
     func configure(with channel: Channel) {
         profileImageView.setImage(
-            with: channel.imageURL,
+            from: channel.imageURL,
             size: CGSize(width: 48, height: 48),
             placeholderImage: UIImage(named: "profile")
         )

--- a/Bridge/Sources/Presentation/Tab/Management/ApplicantList/Cell/ApplicantCell.swift
+++ b/Bridge/Sources/Presentation/Tab/Management/ApplicantList/Cell/ApplicantCell.swift
@@ -114,7 +114,7 @@ final class ApplicantCell: BaseCollectionViewCell {
 
 extension ApplicantCell {
     func configureCell(with data: ApplicantProfile) {
-        profileImageView.setImage(with: data.imageURL, size: CGSize(width: 44, height: 44), placeholderImage: nil)
+        profileImageView.setImage(from: data.imageURL, size: CGSize(width: 44, height: 44), placeholderImage: nil)
         
         let fieldsText = data.fields.joined(separator: ", ")
         

--- a/Bridge/Sources/Presentation/Tab/MyPage/Detail/Profile/Base/BaseProfileEditorViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/MyPage/Detail/Profile/Base/BaseProfileEditorViewController.swift
@@ -293,7 +293,7 @@ extension BaseProfileEditorViewController {
             profileImageView.image = profileImage
         } else {
             profileImageView.setImage(
-                with: profile.imageURL,
+                from: profile.imageURL,
                 size: CGSize(width: 92, height: 92),
                 placeholderImage: UIImage(named: "profile.medium")
             )

--- a/Bridge/Sources/Presentation/Tab/MyPage/Detail/Profile/Base/BaseProfileViewController.swift
+++ b/Bridge/Sources/Presentation/Tab/MyPage/Detail/Profile/Base/BaseProfileViewController.swift
@@ -212,7 +212,7 @@ class BaseProfileViewController: BaseViewController {
 extension BaseProfileViewController {
     func configure(with profile: Profile) {
         // 프로필 이미지 설정
-        profileImageView.setImage(with: profile.imageURL, size: CGSize(width: 155, height: 153))
+        profileImageView.setImage(from: profile.imageURL, size: CGSize(width: 155, height: 153))
         
         // 이름 설정
         nameLabel.text = "\(profile.name) 님"

--- a/Bridge/Sources/Presentation/Tab/MyPage/Home/ProfileHeaderView.swift
+++ b/Bridge/Sources/Presentation/Tab/MyPage/Home/ProfileHeaderView.swift
@@ -143,7 +143,7 @@ extension ProfileHeaderView {
             
             
         case .authorized(let profilePreview):
-            profileImageView.setImage(with: profilePreview.imageURL, size: CGSize(width: 64, height: 64))
+            profileImageView.setImage(from: profilePreview.imageURL, size: CGSize(width: 64, height: 64))
             nameLabel.text = "\(profilePreview.name) 님"
             nameLabel.textColor = BridgeColor.gray01
             manageProfileButton.flex.display(.flex)


### PR DESCRIPTION
## 배경
- 이미지 다운로드 네트워킹을 최소화하여 UX를 개선하기 위해

## 작업 내용
- close #121 

## 스크린샷 
- <img src = "https://github.com/bridge0813/bridge-ios/assets/99619107/272c1cda-987a-494e-85e7-9a9b65b4ca04" height = 600>

## 전체적인 프로세스
1. 메모리에서 캐시된 이미지 데이터 찾기(실패하면 아래 단계 진행)
2. 디스크에서 캐시된 이미지 데이터 찾기(실패하면 아래 단계 진행)
3. url을 통해 이미지 다운로드 후 반환

- 위 순서로 돌아가며, 이미지 데이터를 찾으면 ImageProcessor를 통해 이미지를 처리 후 반환합니다.

## 메모리 저장소(MemoryStorage)
- 메모리에 캐시되는 데이터의 만료일은 5분입니다. 
- 타이머를 통해 240초 주기로 캐시된 데이터를 추적하여, 만료된 데이터가 있으면 제거합니다.

## 디스크 저장소(DiskStorage)
- 디스크에 캐시되는 데이터의 만료일은 7일입니다.
- 앱이 백그라운드 진입 시, 디렉토리 내에 있는 데이터의 만료일을 체크하여 제거합니다.

## 리뷰 노트
- 호윤님은 이미 경험해보셨지만, 궁금한 점 있으시면 질문주세요!
- [이미지 캐시 정리](https://iosjiho.tistory.com/162)
- [캐시정책 정리](https://iosjiho.tistory.com/164)
- [다운샘플링 정리](https://iosjiho.tistory.com/163)
- 다음 작업은 전체적인 테스트를 할 예정입니다.
